### PR TITLE
Use native logger in c++

### DIFF
--- a/beacon/beacon_setup_service.cpp
+++ b/beacon/beacon_setup_service.cpp
@@ -18,16 +18,18 @@
 
 #include "beacon_manager.hpp"
 #include "beacon_setup_service.hpp"
+#include "logging.hpp"
 #include "serialisers.hpp"
 #include "set_intersection.hpp"
 
 #include <assert.h>
-#include <iostream>
 #include <mutex>
 #include <utility>
 
 namespace fetch {
 namespace beacon {
+
+static constexpr char const *LOGGING_NAME = "BeaconSetupService";
 
 BeaconSetupService::BeaconSetupService(Identifier cabinet_size, CabinetIndex threshold,
                                        Identifier index)
@@ -226,7 +228,8 @@ BeaconSetupService::SerialisedMsg BeaconSetupService::GetQualComplaints()
   {
     qual_complaints_manager_.AddComplaintAgainst(mem.first);
   }
-  std::cout << "GetQualComplaints (" << beacon_->cabinet_index() << "): complaints size " << complaints.size() << std::endl;
+  Log(LogLevel::DEBUG, LOGGING_NAME, "GetQualComplaints(" + std::to_string(beacon_->cabinet_index()) + 
+    "): size " + std::to_string(complaints.size()));
   return serialisers::Serialise(complaints);
 }
 
@@ -305,7 +308,8 @@ void BeaconSetupService::OnComplaints(SerialisedMsg const &msg, Identifier const
 
   std::set<Identifier>          complaints;
   serialisers::Deserialise(msg, complaints);
-  std::cout << "OnComplaints (" << from << "->" << beacon_->cabinet_index() << "): complaints size " << complaints.size() << std::endl;
+  Log(LogLevel::DEBUG, LOGGING_NAME, "OnComplaints(" + std::to_string(from) + "->" + 
+    std::to_string(beacon_->cabinet_index()) + "): size " + std::to_string(complaints.size()));
   complaints_manager_.AddComplaintsFrom(from, complaints, valid_dkg_members_);
 }
 
@@ -323,7 +327,8 @@ void BeaconSetupService::OnComplaintAnswers(SerialisedMsg const &msg, Identifier
 
   SharesExposedMap              answer;
   serialisers::Deserialise(msg, answer);
-  std::cout << "OnComplaintsAnswer (" << from << "->" << beacon_->cabinet_index() << "): complaint answer size " << answer.size() << std::endl;
+  Log(LogLevel::DEBUG, LOGGING_NAME, "OnComplaintsAnswer(" + std::to_string(from) + "->" +
+    std::to_string(beacon_->cabinet_index()) + "): size " + std::to_string(answer.size()));
   complaint_answers_manager_.AddComplaintAnswerFrom(from, answer);
 }
 
@@ -362,7 +367,8 @@ void BeaconSetupService::OnQualComplaints(SerialisedMsg const &msg, Identifier c
 
   SharesExposedMap              shares;
   serialisers::Deserialise(msg, shares);
-  std::cout << "OnQualComplaints (" << from << "->" << beacon_->cabinet_index() << "): complaint size " << shares.size() << std::endl;
+  Log(LogLevel::DEBUG, LOGGING_NAME, "OnQualComplaints(" + std::to_string(from) + "->" + 
+    std::to_string(beacon_->cabinet_index()) + "): size " + std::to_string(shares.size()));
   qual_complaints_manager_.AddComplaintsFrom(from, shares);
 }
 
@@ -382,7 +388,8 @@ void BeaconSetupService::OnReconstructionShares(SerialisedMsg const &msg, Identi
   {
     SharesExposedMap              shares;
     serialisers::Deserialise(msg, shares);
-    std::cout << "OnReconstructionShares (" << from << "->" << beacon_->cabinet_index() << "): shares size " << shares.size() << std::endl;
+    Log(LogLevel::DEBUG, LOGGING_NAME, "OnReconstructionShares(" + std::to_string(from) + "->" +
+      std::to_string(beacon_->cabinet_index()) + "): size " + std::to_string(shares.size()));
     reconstruction_shares_received_.insert({from, shares});
   }
 }
@@ -420,7 +427,8 @@ std::set<BeaconSetupService::Identifier> BeaconSetupService::ComputeComplaints()
   {
     complaints_manager_.AddComplaintAgainst(cab);
   }
-  std::cout << "ComputeComplaints (" << beacon_->cabinet_index() << "): complaint size " << complaints_local.size() << std::endl;
+  Log(LogLevel::DEBUG, LOGGING_NAME, "ComputeComplaints(" + std::to_string(beacon_->cabinet_index()) +
+    "): size " + std::to_string(complaints_local.size()));
   return complaints_local;
 }
 

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -195,7 +195,7 @@ func (dkg *DistributedKeyGeneration) OnBlock(blockHeight int64, trxs []*types.DK
 		// Check msg is from validators and verify signature
 		index, val := dkg.validators.GetByAddress(msg.FromAddress)
 		if err := dkg.checkMsg(msg, index, val); err != nil {
-			dkg.Logger.Error("OnBlock: check msg", "height", blockHeight, "msg", msg, "err", err)
+			dkg.Logger.Debug("OnBlock: check msg", "height", blockHeight, "from", msg.FromAddress, "err", err)
 			continue
 		}
 

--- a/beacon/dkg_test.go
+++ b/beacon/dkg_test.go
@@ -178,6 +178,8 @@ func TestDKGScenarios(t *testing.T) {
 		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			nodes := exampleDKGNetwork(tc.nVals, tc.sendDuplicates)
+			cppLogger := NewNativeLoggingCollector(log.TestingLogger())
+			cppLogger.Start()
 
 			outputs := make([]*aeonDetails, tc.completionSize)
 			for index := 0; index < tc.completionSize; index++ {
@@ -262,6 +264,8 @@ func TestDKGScenarios(t *testing.T) {
 			for index := 0; index < tc.completionSize; index++ {
 				assert.True(t, outputs[index].aeonExecUnit.VerifyGroupSignature(message, groupSig))
 			}
+
+			cppLogger.Stop()
 		})
 	}
 }
@@ -294,7 +298,8 @@ func newTestNode(config *cfg.ConsensusConfig, chainID string, privVal types.Priv
 		failures:     make([]dkgFailure, 0),
 		sentBadShare: false,
 	}
-	node.dkg.SetLogger(log.TestingLogger())
+	index, _ := vals.GetByAddress(privVal.GetPubKey().Address())
+	node.dkg.SetLogger(log.TestingLogger().With("dkgIndex", index))
 
 	node.dkg.SetSendMsgCallback(func(msg *types.DKGMessage) {
 		node.mutateMsg(msg)

--- a/beacon/serialisers.cpp
+++ b/beacon/serialisers.cpp
@@ -16,6 +16,7 @@
 //
 //------------------------------------------------------------------------------
 
+#include "logging.hpp"
 #include "serialisers.hpp"
 
 #include <boost/archive/text_iarchive.hpp>
@@ -25,11 +26,12 @@
 #include <boost/serialization/unordered_map.hpp>
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/vector.hpp>
-#include <iostream>
 #include <sstream>
 
 namespace fetch {
 namespace serialisers {
+
+static constexpr char const *LOGGING_NAME = "Serialisers";
 
 std::string Serialise(std::vector<std::string> const &coeff) {
   std::ostringstream            ss;
@@ -68,7 +70,7 @@ bool Deserialise(std::string const &msg, std::vector<std::string> &coeff) {
   } 
   catch (boost::archive::archive_exception ex) 
   {
-    std::cerr << "Error deserialising coefficients: " << ex.what() << std::endl;
+    Log(LogLevel::ERROR, LOGGING_NAME, "Coefficients: " + std::string(ex.what()));
     coeff.clear();
     return false;
   }
@@ -84,7 +86,7 @@ bool Deserialise(std::string const &msg, std::pair<std::string, std::string> &sh
   } 
   catch (boost::archive::archive_exception ex) 
   {
-    std::cerr << "Error deserialising shares: " << ex.what() << std::endl;
+    Log(LogLevel::ERROR, LOGGING_NAME, "Shares: " + std::string(ex.what()));
     shares = {};
     return false;
   }
@@ -100,7 +102,7 @@ bool Deserialise(std::string const &msg, std::set<uint32_t> &complaints) {
   } 
   catch (boost::archive::archive_exception ex) 
   {
-    std::cerr << "Error deserialising complaints: " << ex.what() << std::endl;
+    Log(LogLevel::ERROR, LOGGING_NAME, "Complaints: " + std::string(ex.what()));
     complaints.clear();
     return false;
   }
@@ -116,7 +118,7 @@ bool Deserialise(std::string const &msg, std::unordered_map<uint32_t, std::pair<
   } 
   catch (boost::archive::archive_exception ex) 
   {
-    std::cerr << "Error deserialising exposed shares: " << ex.what() << std::endl;
+    Log(LogLevel::ERROR, LOGGING_NAME, "Exposed shares: " + std::string(ex.what()));
     shares.clear();
     return false;
   }


### PR DESCRIPTION
Tidied log messages by replacing print statements in C++ to use native logger.