### PR TITLE
Iterate through validator changes in order

### DIFF
--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -346,7 +346,8 @@ func processChanges(origChanges []*Validator) (updates, removals []*Validator, e
 	var prevAddr Address
 
 	// Scan changes by address and append valid validators to updates or removals lists.
-	for _, valUpdate := range changes {
+	for i := 0; i < len(changes); i++ {
+		valUpdate := changes[i]
 		if bytes.Equal(valUpdate.Address, prevAddr) {
 			err = fmt.Errorf("duplicate entry %v in %v", valUpdate, changes)
 			return nil, nil, err


### PR DESCRIPTION
Possible bug in Tendermint validator code where processing of validator changes should iterate through changes in order but for loop iteration via range does not preserve order as far as I understand.