### PR TITLE
Bug fix on dkg validator indices in aeon details

### DIFF
--- a/beacon/aeon_details.go
+++ b/beacon/aeon_details.go
@@ -57,20 +57,13 @@ func newAeonDetails(newPrivValidator types.PrivValidator, valHeight int64,
 	if startHeight <= 0 || endHeight < startHeight {
 		panic(fmt.Errorf("aeonDetails invalid start/end height"))
 	}
-	qual := make([]*types.Validator, 0)
-	for index := 0; index < len(validators.Validators); index++ {
-		if aeonKeys.InQual(uint(index)) {
-			qual = append(qual, validators.Validators[index])
-		}
-	}
-	newVals := types.NewValidatorSet(qual)
 	if aeonKeys.CanSign() {
 		if newPrivValidator == nil {
 			panic(fmt.Errorf("aeonDetails has DKG keys but no privValidator"))
 		}
-		index, _ := newVals.GetByAddress(newPrivValidator.GetPubKey().Address())
-		if index < 0 {
-			panic(fmt.Errorf("aeonDetails has DKG keys but not in validators"))
+		index, _ := validators.GetByAddress(newPrivValidator.GetPubKey().Address())
+		if index < 0 || !aeonKeys.InQual(uint(index)) {
+			panic(fmt.Errorf("aeonDetails has DKG keys but not in validators or qual"))
 		}
 		if !aeonKeys.CheckIndex(uint(index)) {
 			i := 0
@@ -84,7 +77,7 @@ func newAeonDetails(newPrivValidator types.PrivValidator, valHeight int64,
 	ad := &aeonDetails{
 		privValidator:   newPrivValidator,
 		validatorHeight: valHeight,
-		validators:      newVals,
+		validators:      types.NewValidatorSet(validators.Validators),
 		aeonExecUnit:    aeonKeys,
 		threshold:       validators.Size()/2 + 1,
 		Start:           startHeight,

--- a/beacon/aeon_exec_unit.cpp
+++ b/beacon/aeon_exec_unit.cpp
@@ -69,20 +69,16 @@ AeonExecUnit::AeonExecUnit(std::string generator, DKGKeyInformation keys, std::s
   , generator_{std::move(generator)}
   , qual_{std::move(qual)} 
   {
-  assert(aeon_keys_.public_key_shares.size() == qual_.size());
   CheckKeys();
 }
 
 AeonExecUnit::AeonExecUnit(std::string const &generator, DKGKeyInformation const &keys, std::vector<CabinetIndex> const &qual) 
 {
-  std::set<CabinetIndex> qual_set;
   for (auto const &index : qual) {
-    qual_set.insert(index);
+    qual_.insert(index);
   }
   aeon_keys_ = keys;
   generator_ = generator;
-  qual_ = std::move(qual_set);
-  assert(aeon_keys_.public_key_shares.size() == qual_.size());
   CheckKeys();
 }
 

--- a/beacon/beacon_manager.cpp
+++ b/beacon/beacon_manager.cpp
@@ -502,9 +502,9 @@ AeonExecUnit BeaconManager::GetDkgOutput() const
   auto output             = DKGKeyInformation();
   output.group_public_key = public_key_.ToString();
   output.private_key      = secret_share_.ToString();
-  for (auto elem : qual_)
+  for (auto elem : public_key_shares_)
   {
-    output.public_key_shares.push_back(public_key_shares_[elem].ToString());
+    output.public_key_shares.push_back(elem.ToString());
   }
   AeonExecUnit aeon{GetGroupG().ToString(), output, qual_};
   return aeon;

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -268,7 +268,6 @@ func (dkg *DistributedKeyGeneration) OnBlock(blockHeight int64, trxs []*types.DK
 		dkg.checkTransition(blockHeight)
 		return
 	}
-	dkg.Logger.Debug("OnBlock: received transactions", "height", blockHeight, "numTrx", len(trxs))
 	// Process transactions
 	for _, trx := range trxs {
 		// Decode transaction
@@ -406,8 +405,6 @@ func (dkg *DistributedKeyGeneration) checkTransition(blockHeight int64) {
 		dkg.states[dkg.currentState].onEntry()
 		// Run check transition again in case we can proceed to the next state already
 		dkg.checkTransition(blockHeight)
-	} else {
-		dkg.Logger.Debug("checkTransition: no state change", "height", blockHeight, "state", dkg.currentState, "iteration", dkg.dkgIteration)
 	}
 }
 
@@ -583,7 +580,7 @@ func (dkg *DistributedKeyGeneration) receivedAllDryRuns() bool {
 
 func (dkg *DistributedKeyGeneration) checkDryRuns() bool {
 	encodedOutput := ""
-	requiredPassSize := uint(2 * dkg.validators.Size() / 3)
+	requiredPassSize := uint((2 * dkg.validators.Size()) / 3)
 	if requiredPassSize < dkg.threshold {
 		requiredPassSize = dkg.threshold
 	}

--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -250,7 +250,7 @@ func (entropyGenerator *EntropyGenerator) changeKeys() bool {
 func (entropyGenerator *EntropyGenerator) applyComputedEntropy(height int64, entropy types.ThresholdSignature) {
 	// Should not be called in entropy generator is not running
 	if !entropyGenerator.isSigningEntropy() {
-		panic(fmt.Errorf("applyEntropyShare while entropy generator stopped"))
+		panic(fmt.Errorf("applyComputedEntropy while entropy generator stopped"))
 	}
 	entropyGenerator.mtx.Lock()
 	defer entropyGenerator.mtx.Unlock()
@@ -344,7 +344,7 @@ func (entropyGenerator *EntropyGenerator) getEntropyShares(height int64) map[uin
 }
 
 func (entropyGenerator *EntropyGenerator) validInputs(height int64, index int) error {
-	if index < 0 {
+	if index < 0 || !entropyGenerator.aeon.aeonExecUnit.InQual(uint(index)) {
 		return fmt.Errorf("invalid validator index %v", index)
 	}
 	if height != entropyGenerator.lastBlockHeight+1 {


### PR DESCRIPTION
- Aeon details previously assigned the qual members of the DKG new indices by making a new validator set with only qual. This is wrong and will result in a failure to verify the group signature as all members must keep the indices assigned to them in the original set of validators on starting the DKG.