### PR TITLE
Changed default value of allow_duplicate_ip to true

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -595,7 +595,7 @@ func DefaultP2PConfig() *P2PConfig {
 		RecvRate:                5120000, // 5 mB/s
 		PexReactor:              true,
 		SeedMode:                false,
-		AllowDuplicateIP:        false,
+		AllowDuplicateIP:        true,
 		HandshakeTimeout:        20 * time.Second,
 		DialTimeout:             3 * time.Second,
 		TestDialFail:            false,


### PR DESCRIPTION
This PR changes the default value of allow_duplicate_ip to true

This is necessary as we will have multiple sentry nodes behind the same IP.

If we do not set this value to true, then external nodes will choose to connect to only one of the internal cluster nodes, and not all of them