### PR TITLE
Save block entropy to state

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -454,6 +454,7 @@ func updateState(
 		LastHeightConsensusParamsChanged: lastHeightParamsChanged,
 		LastResultsHash:                  abciResponses.ResultsHash(),
 		AppHash:                          nil,
+		LastComputedEntropy:              header.Entropy.GroupSignature,
 	}, nil
 }
 


### PR DESCRIPTION
Copy the group signature in block into the LastComputedEntropy field of the state.