### PR TITLE
avoid nil dereference in P2P test

### DIFF
--- a/p2p/conn/connection.go
+++ b/p2p/conn/connection.go
@@ -313,6 +313,9 @@ func (c *MConnection) OnStop() {
 }
 
 func (c *MConnection) String() string {
+	if c.conn == nil {
+		return "NIL"
+	}
 	return fmt.Sprintf("MConn{%v}", c.conn.RemoteAddr())
 }
 


### PR DESCRIPTION
Can cause tests to fail by panic