### PR TITLE
Add metric for block production failures

### DIFF
--- a/consensus/metrics.go
+++ b/consensus/metrics.go
@@ -58,6 +58,9 @@ type Metrics struct {
 
 	// Number of blockparts transmitted by peer.
 	BlockParts metrics.Counter
+
+	// Number of times failed as block producer
+	NumFailuresAsBlockProducer metrics.Counter
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -180,6 +183,12 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "block_parts",
 			Help:      "Number of blockparts transmitted by peer.",
 		}, append(labels, "peer_id")).With(labelsAndValues...),
+		NumFailuresAsBlockProducer: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "block_producer_failures",
+			Help:      "Number of times failed as block producer",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -209,5 +218,7 @@ func NopMetrics() *Metrics {
 		CommittedHeight: discard.NewGauge(),
 		FastSyncing:     discard.NewGauge(),
 		BlockParts:      discard.NewCounter(),
+
+		NumFailuresAsBlockProducer: discard.NewCounter(),
 	}
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -139,7 +139,8 @@ type ConsensusState struct {
 	evsw tmevents.EventSwitch
 
 	// for reporting metrics
-	metrics *Metrics
+	isProposerForHeight int
+	metrics             *Metrics
 
 	// Last entropy and channel for receiving entropy
 	newEntropy            map[int64]*types.ChannelEntropy
@@ -979,6 +980,7 @@ func (cs *ConsensusState) enterPropose(height int64, round int) {
 			nextProposer.Address,
 			"privValidator",
 			cs.privValidator)
+		cs.isProposerForHeight++
 		cs.decideProposal(height, round)
 	} else {
 		logger.Info("enterPropose: Not our turn to propose",
@@ -1750,6 +1752,11 @@ func (cs *ConsensusState) recordMetrics(height int64, block *types.Block) {
 	cs.metrics.TotalTxs.Add(float64(len(block.Data.Txs)))
 	cs.metrics.BlockSizeBytes.Set(float64(block.Size()))
 	cs.metrics.CommittedHeight.Set(float64(block.Height))
+
+	if cs.isProposerForHeight != 0 && bytes.Equal(block.ProposerAddress, cs.privValidator.GetPubKey().Address()) {
+		cs.metrics.NumFailuresAsBlockProducer.Add(float64(cs.isProposerForHeight))
+	}
+	cs.isProposerForHeight = 0
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds metric to consensus for recording the number of times a node was selected as block producer but failed to produce a block.