### PR TITLE
Stop beacon reactor before consensus in switch

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -3,6 +3,7 @@ package p2p
 import (
 	"fmt"
 	"math"
+	"sort"
 	"sync"
 	"time"
 
@@ -239,10 +240,18 @@ func (sw *Switch) OnStop() {
 		sw.stopAndRemovePeer(p, nil)
 	}
 
-	// Stop reactors
+	// Stop reactors in key order - beacon reactor
+	// needs to close entropy channel before consensus reactor
+	// is stopped
+	var keys []string
+	for key := range sw.reactors {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
 	sw.Logger.Debug("Switch: Stopping reactors")
-	for _, reactor := range sw.reactors {
-		reactor.Stop()
+	for i := 0; i < len(sw.reactors); i++ {
+		sw.reactors[keys[i]].Stop()
 	}
 }
 


### PR DESCRIPTION
Beacon reactor needs to be stopped before consensus reactor in the stopping of the p2p switch. This ensures that the entropy generator closes the entropy channel and the consensus state does not hang waiting for entropy. 