### PR TITLE
Flakey P2P test

### DIFF
--- a/p2p/transport_test.go
+++ b/p2p/transport_test.go
@@ -300,6 +300,8 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 			errc <- err
 			return
 		}
+
+		close(errc)
 	}()
 
 	// Simulate fast Peer.
@@ -322,7 +324,6 @@ func TestTransportMultiplexAcceptNonBlocking(t *testing.T) {
 			return
 		}
 
-		close(errc)
 		close(fastc)
 	}()
 


### PR DESCRIPTION
I think this fixes the p2p test that gave rise to errors of the form 
```
panic: send on closed channel

goroutine 2870 [running]:
github.com/tendermint/tendermint/p2p.TestTransportMultiplexAcceptNonBlocking.func1(0xc0001e3200, 0xc0006e2c60, 0xc0006e2d20, 0xc0006e2cc0)
	/home/runner/work/cosmos-consensus/cosmos-consensus/p2p/transport_test.go:300 +0x4df
created by github.com/tendermint/tendermint/p2p.TestTransportMultiplexAcceptNonBlocking
	/home/runner/work/cosmos-consensus/cosmos-consensus/p2p/transport_test.go:269 +0x265
```