### PR TITLE
Fix blockchain flakey tests

### DIFF
--- a/beacon/dkg_test.go
+++ b/beacon/dkg_test.go
@@ -250,7 +250,7 @@ func TestDKGScenarios(t *testing.T) {
 					}
 				}
 				return running == 0
-			}, 1*time.Second, 100*time.Microsecond)
+			}, 1*time.Second, 100*time.Millisecond)
 
 			// Check outputs have been set
 			for _, aeon := range outputs {

--- a/beacon/entropy_generator_test.go
+++ b/beacon/entropy_generator_test.go
@@ -94,7 +94,7 @@ func TestEntropyGeneratorNonValidator(t *testing.T) {
 		newGen.applyEntropyShare(&share)
 	}
 
-	assert.Eventually(t, func() bool { return newGen.getLastComputedEntropyHeight() == 1 }, time.Second, 100*time.Microsecond)
+	assert.Eventually(t, func() bool { return newGen.getLastComputedEntropyHeight() == 1 }, time.Second, 10*time.Millisecond)
 }
 
 func TestEntropyGeneratorSign(t *testing.T) {
@@ -223,7 +223,7 @@ func TestEntropyGeneratorFlush(t *testing.T) {
 	newGen.SetLastComputedEntropy(0, []byte("Test Entropy"))
 	newGen.Start()
 
-	assert.Eventually(t, func() bool { return newGen.getComputedEntropy(21) != nil }, 3*time.Second, 100*time.Microsecond)
+	assert.Eventually(t, func() bool { return newGen.getComputedEntropy(21) != nil }, 3*time.Second, 500*time.Millisecond)
 	newGen.Stop()
 	newGen.wait()
 	assert.True(t, len(newGen.entropyShares) <= entropyHistoryLength+1)
@@ -277,7 +277,7 @@ func TestEntropyGeneratorApplyComputedEntropy(t *testing.T) {
 			otherGen.applyEntropyShare(&share)
 		}
 
-		assert.Eventually(t, func() bool { return otherGen.getLastComputedEntropyHeight() >= 2 }, time.Second, 100*time.Microsecond)
+		assert.Eventually(t, func() bool { return otherGen.getLastComputedEntropyHeight() >= 2 }, time.Second, 10*time.Millisecond)
 		newGen.applyComputedEntropy(2, otherGen.getComputedEntropy(2))
 		assert.True(t, bytes.Equal(newGen.getComputedEntropy(2), otherGen.getComputedEntropy(2)))
 	})
@@ -296,7 +296,7 @@ func TestEntropyGeneratorChangeKeys(t *testing.T) {
 	newGen.SetNextAeonDetails(aeonDetails)
 
 	newGen.Start()
-	assert.Eventually(t, func() bool { return newGen.isSigningEntropy() }, time.Second, 100*time.Microsecond)
+	assert.Eventually(t, func() bool { return newGen.isSigningEntropy() }, time.Second, 100*time.Millisecond)
 }
 
 func groupTestSetup(nValidators int) (sm.State, []types.PrivValidator) {

--- a/beacon/reactor_test.go
+++ b/beacon/reactor_test.go
@@ -128,7 +128,7 @@ func TestReactorEntropy(t *testing.T) {
 			}
 		}
 		return true
-	}, 30*time.Second, 100*time.Microsecond)
+	}, 30*time.Second, 500*time.Millisecond)
 	for i := 0; i < N; i++ {
 		assert.Equal(t, int64(29), entropyGenerators[i].getLastComputedEntropyHeight())
 	}
@@ -195,7 +195,7 @@ func TestReactorWithConsensus(t *testing.T) {
 			return true
 		}
 		return false
-	}, 3*time.Minute, 100*time.Microsecond, "Failed to produce 3 blocks. Last block height %v", lastBlockHeight)
+	}, 3*time.Minute, 100*time.Millisecond, "Failed to produce 3 blocks. Last block height %v", lastBlockHeight)
 
 }
 func TestReactorCatchupWithBlocks(t *testing.T) {
@@ -317,7 +317,7 @@ func TestReactorWithDKG(t *testing.T) {
 			}
 		}
 		return running == 0
-	}, 1*time.Second, 100*time.Microsecond)
+	}, 1*time.Second, 100*time.Millisecond)
 
 	// Change keys over
 	for _, entropyGen := range entropyGenerators {
@@ -337,5 +337,5 @@ func TestReactorWithDKG(t *testing.T) {
 			}
 		}
 		return true
-	}, 3*time.Second, 100*time.Microsecond)
+	}, 3*time.Second, 100*time.Millisecond)
 }

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/snikch/goodman v0.0.0-20171125024755-10e37e294daa
 	github.com/spf13/cobra v0.0.1
 	github.com/spf13/viper v1.5.0
-	github.com/stretchr/testify v1.4.0
+	github.com/stretchr/testify v1.5.1
 	github.com/stumble/gorocksdb v0.0.3 // indirect
 	github.com/tendermint/go-amino v0.14.1
 	github.com/tendermint/tm-db v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
-github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stumble/gorocksdb v0.0.3 h1:9UU+QA1pqFYJuf9+5p7z1IqdE5k0mma4UAeu2wmX8kA=
 github.com/stumble/gorocksdb v0.0.3/go.mod h1:v6IHdFBXk5DJ1K4FZ0xi+eY737quiiBxYtSWXadLybY=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=


### PR DESCRIPTION
Fix issues related to flakey tests:
1. More details mentioned in https://github.com/tendermint/tendermint/issues/3400
```
panic: BlockStore can only save contiguous blocks. Wanted 149, got 1
goroutine 1407 [running]:
github.com/tendermint/tendermint/store.(*BlockStore).SaveBlock(0xc0011723c0, 0xc0012a7a00, 0xc001234960, 0xc000cf2c00)
	/home/runner/work/cosmos-consensus/cosmos-consensus/store/store.go:152 +0x6e4
github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).poolRoutine(0xc0000d4fc0)
	/home/runner/work/cosmos-consensus/cosmos-consensus/blockchain/v0/reactor.go:336 +0x8e2
created by github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).OnStart
	/home/runner/work/cosmos-consensus/cosmos-consensus/blockchain/v0/reactor.go:118 +0x84
FAIL	github.com/tendermint/tendermint/blockchain/v0	3.376s
```
2. 
```
--- FAIL: TestPeerResetBlockResponseTimer (0.01s)
    peer_test.go:69: 
        	Error Trace:	peer_test.go:69
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 0
        	Test:       	TestPeerResetBlockResponseTimer
    peer_test.go:70: 
        	Error Trace:	peer_test.go:70
        	Error:      	Not equal: 
        	            	expected: <nil>(<nil>)
        	            	actual  : *errors.errorString(&errors.errorString{s:"fast sync timed out on peer block response"})
        	Test:       	TestPeerResetBlockResponseTimer
```