### PR TITLE
Bug fix in saving old keys on changeover

### DIFF
--- a/beacon/common_test.go
+++ b/beacon/common_test.go
@@ -132,7 +132,7 @@ func randBeaconAndConsensusNet(nValidators int, testName string, withConsensus b
 		entropyGenerators[i] = NewEntropyGenerator(&thisConfig.BaseConfig, thisConfig.Beacon, 0)
 		entropyGenerators[i].SetLogger(logger)
 		entropyGenerators[i].SetLastComputedEntropy(0, state.LastComputedEntropy)
-		entropyGenerators[i].SetAeonDetails(aeonDetails)
+		entropyGenerators[i].SetNextAeonDetails(aeonDetails)
 
 		if withConsensus {
 			ensureDir(filepath.Dir(thisConfig.Consensus.WalFile()), 0700) // dir for wal

--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -134,27 +134,6 @@ func (entropyGenerator *EntropyGenerator) SetLogger(l log.Logger) {
 	entropyGenerator.BaseService.Logger = l
 }
 
-// SetAeonDetails sets the DKG keys for computing DRB (used on creation of NewNode)
-func (entropyGenerator *EntropyGenerator) SetAeonDetails(aeon *aeonDetails) {
-	entropyGenerator.mtx.Lock()
-	defer entropyGenerator.mtx.Unlock()
-
-	// Check entropy keys are not old
-	if entropyGenerator.lastBlockHeight+1 > aeon.End {
-		return
-	}
-
-	// When updating the aeon, we save the current aeon so that in the event of a crash we
-	// can load it since the block height may still be within this old aeon (entropy leads block height)
-	if entropyGenerator.aeon != nil {
-		entropyGenerator.aeon.save(entropyGenerator.baseConfig.OldEntropyKeyFile())
-	}
-
-	entropyGenerator.aeon = aeon
-
-	entropyGenerator.UpdateMetrics()
-}
-
 // SetLastComputedEntropy sets the most recent entropy from catchup
 func (entropyGenerator *EntropyGenerator) SetLastComputedEntropy(height int64, entropy types.ThresholdSignature) {
 	entropyGenerator.mtx.Lock()
@@ -230,6 +209,10 @@ func (entropyGenerator *EntropyGenerator) resetKeys() bool {
 
 	// Reset current aeon to nil if it is no longer relevant
 	if entropyGenerator.aeon != nil && entropyGenerator.lastBlockHeight >= entropyGenerator.aeon.End {
+		// When updating the aeon, we save the current aeon so that in the event of a crash we
+		// can load it since the block height may still be within this old aeon (entropy leads block height)
+		entropyGenerator.aeon.save(entropyGenerator.baseConfig.OldEntropyKeyFile())
+
 		entropyGenerator.Logger.Info("changeKeys: Existing keys expired.", "blockHeight", entropyGenerator.lastBlockHeight,
 			"end", entropyGenerator.aeon.End)
 		entropyGenerator.aeon = nil

--- a/beacon/entropy_generator_test.go
+++ b/beacon/entropy_generator_test.go
@@ -29,7 +29,7 @@ func TestEntropyGeneratorStart(t *testing.T) {
 			state, _ := groupTestSetup(nValidators)
 			aeonExecUnit := NewAeonExecUnit("test_keys/non_validator.txt")
 			aeonDetails, _ := newAeonDetails(nil, 1, state.Validators, aeonExecUnit, 1, 10)
-			eg.SetAeonDetails(aeonDetails)
+			eg.SetNextAeonDetails(aeonDetails)
 		}},
 	}
 	for _, tc := range testCases {
@@ -64,7 +64,8 @@ func TestEntropyGeneratorSetAeon(t *testing.T) {
 			state, _ := groupTestSetup(4)
 			aeonExecUnit := NewAeonExecUnit("test_keys/non_validator.txt")
 			aeonDetails, _ := newAeonDetails(nil, 1, state.Validators, aeonExecUnit, tc.start, tc.end)
-			newGen.SetAeonDetails(aeonDetails)
+			newGen.SetNextAeonDetails(aeonDetails)
+			newGen.changeKeys()
 			assert.Equal(t, newGen.isSigningEntropy(), tc.aeonSet)
 		})
 	}
@@ -118,7 +119,7 @@ func TestEntropyGeneratorSign(t *testing.T) {
 }
 
 func TestEntropyGeneratorApplyShare(t *testing.T) {
-	nValidators := 3
+	nValidators := 4
 	state, privVals := groupTestSetup(nValidators)
 
 	// Set up non-validator
@@ -219,7 +220,7 @@ func TestEntropyGeneratorFlush(t *testing.T) {
 
 	aeonExecUnit := NewAeonExecUnit("test_keys/single_validator.txt")
 	aeonDetails, _ := newAeonDetails(privVal[0], 1, state.Validators, aeonExecUnit, 1, 50)
-	newGen.SetAeonDetails(aeonDetails)
+	newGen.SetNextAeonDetails(aeonDetails)
 	newGen.SetLastComputedEntropy(0, []byte("Test Entropy"))
 	newGen.Start()
 
@@ -231,7 +232,7 @@ func TestEntropyGeneratorFlush(t *testing.T) {
 }
 
 func TestEntropyGeneratorApplyComputedEntropy(t *testing.T) {
-	nValidators := 3
+	nValidators := 4
 	state, privVals := groupTestSetup(nValidators)
 
 	// Set up non-validator
@@ -286,7 +287,7 @@ func TestEntropyGeneratorApplyComputedEntropy(t *testing.T) {
 func TestEntropyGeneratorChangeKeys(t *testing.T) {
 	newGen := testEntropyGenerator()
 	newGen.SetLogger(log.TestingLogger())
-	newGen.SetAeonDetails(keylessAeonDetails(0, 4))
+	newGen.SetNextAeonDetails(keylessAeonDetails(0, 4))
 
 	assert.True(t, !newGen.isSigningEntropy())
 
@@ -315,8 +316,9 @@ func testEntropyGen(validators *types.ValidatorSet, privVal types.PrivValidator,
 		aeonExecUnit = NewAeonExecUnit("test_keys/" + strconv.Itoa(int(index)) + ".txt")
 	}
 	aeonDetails, _ := newAeonDetails(privVal, 1, validators, aeonExecUnit, 1, 50)
-	newGen.SetAeonDetails(aeonDetails)
+	newGen.SetNextAeonDetails(aeonDetails)
 	newGen.SetLastComputedEntropy(0, []byte("Test Entropy"))
+	newGen.changeKeys()
 	return newGen
 }
 

--- a/beacon/reactor_test.go
+++ b/beacon/reactor_test.go
@@ -111,7 +111,7 @@ func TestReactorEntropy(t *testing.T) {
 	// Add second set of keys so entropy generations has patten ON, OFF, ON
 	aeonKeys := setCrypto(N)
 	for i := 0; i < N; i++ {
-		existingAeon := entropyGenerators[i].aeon
+		existingAeon := entropyGenerators[i].nextAeons[0]
 		newKeys, _ := newAeonDetails(existingAeon.privValidator, 1, existingAeon.validators, aeonKeys[i], 20, 29)
 		// Insert in empty keys for gap in entropy generation
 		entropyGenerators[i].SetNextAeonDetails(keylessAeonDetails(10, 19))


### PR DESCRIPTION
Remove redundant function and move saving of previous aeon to before it is reset. Fix tests that use to call delete function.