### PR TITLE
Fix flakey EOF error in privval test

### DIFF
--- a/privval/signer_listener_endpoint_test.go
+++ b/privval/signer_listener_endpoint_test.go
@@ -17,8 +17,8 @@ import (
 var (
 	testTimeoutAccept = defaultTimeoutAcceptSeconds * time.Second
 
-	testTimeoutReadWrite    = 100 * time.Millisecond
-	testTimeoutReadWrite2o3 = 60 * time.Millisecond // 2/3 of the other one
+	testTimeoutReadWrite    = 200 * time.Millisecond
+	testTimeoutReadWrite2o3 = 120 * time.Millisecond // 2/3 of the other one
 )
 
 type dialerTestCase struct {


### PR DESCRIPTION
Insufficient timeouts set in tests result in EOF errors when reading response from signer server. This can be seen by reducing the test timeouts dramatically, which increases the test flakiness.
```
--- FAIL: TestSignerVoteKeepAlive (0.31s)
    signer_client_test.go:196: 
        	Error Trace:	signer_client_test.go:196
        	Error:      	Received unexpected error:
        	            	EOF
        	Test:       	TestSignerVoteKeepAlive
FAIL
FAIL	github.com/tendermint/tendermint/privval	10.502s
```