### PR TITLE
Remove unnecessary wait in stopping entropy generator

### DIFF
--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -47,8 +47,6 @@ type EntropyGenerator struct {
 
 	// closed when shutting down to unblock send to full channel
 	quit chan struct{}
-	// closed when we finish shutting down
-	done chan struct{}
 
 	// Metrics and debug below here
 	metrics                 *Metrics
@@ -79,7 +77,6 @@ func NewEntropyGenerator(bConfig *cfg.BaseConfig, beaconConfig *cfg.BeaconConfig
 		beaconConfig:              beaconConfig,
 		evsw:                      tmevents.NewEventSwitch(),
 		quit:                      make(chan struct{}),
-		done:                      make(chan struct{}),
 		metrics:                   NopMetrics(),
 	}
 
@@ -106,17 +103,6 @@ func (entropyGenerator *EntropyGenerator) OnStart() error {
 func (entropyGenerator *EntropyGenerator) OnStop() {
 	entropyGenerator.evsw.Stop()
 	close(entropyGenerator.quit)
-}
-
-// Wait waits for the computeEntropyRoutine to return.
-func (entropyGenerator *EntropyGenerator) wait() {
-	// Try to stop gracefully by waiting for routine to return
-	t := time.NewTimer(2 * entropyGenerator.beaconConfig.ComputeEntropySleepDuration)
-	select {
-	case <-t.C:
-		panic(fmt.Errorf("wait timeout - deadlock in closing channel"))
-	case <-entropyGenerator.done:
-	}
 }
 
 // SetEntropyChannel sets the channel along which entropy should be dispatched
@@ -442,7 +428,6 @@ func (entropyGenerator *EntropyGenerator) computeEntropyRoutine() {
 		if entropyGenerator.computedEntropyChannel != nil {
 			close(entropyGenerator.computedEntropyChannel)
 		}
-		close(entropyGenerator.done)
 	}
 	defer func() {
 		if r := recover(); r != nil {

--- a/beacon/entropy_generator_test.go
+++ b/beacon/entropy_generator_test.go
@@ -225,7 +225,6 @@ func TestEntropyGeneratorFlush(t *testing.T) {
 
 	assert.Eventually(t, func() bool { return newGen.getComputedEntropy(21) != nil }, 3*time.Second, 500*time.Millisecond)
 	newGen.Stop()
-	newGen.wait()
 	assert.True(t, len(newGen.entropyShares) <= entropyHistoryLength+1)
 	assert.True(t, len(newGen.entropyComputed) <= entropyHistoryLength+1)
 }

--- a/beacon/reactor.go
+++ b/beacon/reactor.go
@@ -80,7 +80,6 @@ func (beaconR *Reactor) OnStop() {
 	beaconR.unsubscribeFromBroadcastEvents()
 	if beaconR.entropyGen.IsRunning() {
 		beaconR.entropyGen.Stop()
-		beaconR.entropyGen.wait()
 	}
 }
 


### PR DESCRIPTION
Removed wait function in entropy generator, which is unnecessary and can cause a panic due to incorrect setting of timeout. This has been seen in the node test (see below). Only important thing when shutting down the entropy generator is to close the channel shared with consensus so that the consensus state does not block waiting on entropy.
```
panic: wait timeout - deadlock in closing channel

goroutine 296 [running]:
github.com/tendermint/tendermint/beacon.(*EntropyGenerator).wait(0xc000440300)
	/go/src/github.com/tendermint/tendermint/beacon/entropy_generator.go:117 +0x133
github.com/tendermint/tendermint/beacon.(*Reactor).OnStop(0xc000b9a700)
	/go/src/github.com/tendermint/tendermint/beacon/reactor.go:83 +0xa0
github.com/tendermint/tendermint/libs/common.(*BaseService).Stop(0xc000b9a700, 0x0, 0x0)
	/go/src/github.com/tendermint/tendermint/libs/common/service.go:167 +0x2f4
github.com/tendermint/tendermint/p2p.(*Switch).OnStop(0xc000d8c120)
	/go/src/github.com/tendermint/tendermint/p2p/switch.go:254 +0x2bf
github.com/tendermint/tendermint/libs/common.(*BaseService).Stop(0xc000d8c120, 0x0, 0x0)
	/go/src/github.com/tendermint/tendermint/libs/common/service.go:167 +0x2f4
github.com/tendermint/tendermint/node.(*Node).OnStop(0xc000445800)
	/go/src/github.com/tendermint/tendermint/node/node.go:965 +0xb9
github.com/tendermint/tendermint/libs/common.(*BaseService).Stop(0xc000445800, 0xc000280060, 0x0)
	/go/src/github.com/tendermint/tendermint/libs/common/service.go:167 +0x2f4
github.com/tendermint/tendermint/node.TestNodeStartStop.func5.1(0xc000445800)
	/go/src/github.com/tendermint/tendermint/node/node_test.go:85 +0x2d
created by github.com/tendermint/tendermint/node.TestNodeStartStop.func5
	/go/src/github.com/tendermint/tendermint/node/node_test.go:84 +0x588
FAIL	github.com/tendermint/tendermint/node	6.185s
```