### PR TITLE
Fix blockchain test

### DIFF
--- a/blockchain/v0/reactor_test.go
+++ b/blockchain/v0/reactor_test.go
@@ -191,7 +191,9 @@ func TestBadBlockStopsPeer(t *testing.T) {
 
 	maxBlockHeight := int64(148)
 
-	otherChain := newBlockchainReactor(log.TestingLogger(), genDoc, privVals, maxBlockHeight)
+	// Other chain needs a different valiator set
+	otherGenDoc, otherPrivVals := randGenesisDoc(1, false, 30)
+	otherChain := newBlockchainReactor(log.TestingLogger(), otherGenDoc, otherPrivVals, maxBlockHeight)
 	defer func() {
 		otherChain.reactor.Stop()
 		otherChain.app.Stop()


### PR DESCRIPTION
Fix error (see below) coming from TestBadBlockStopsPeer in blockchain/v0. Test was generating two different chains with same validator, which could lead to a panic when nodes' are fast syncing the chain. Changed test so that invalid chain is generated by a different validator.
```
panic: V0 BCR Failed to process committed block (5:56DC3F12C0EA9C44D742D9513A7D1905830E15292875937A19353DF13C6AC65F): Wrong Block.Header.LastBlockID.  Expected 02276D438551993FEEF04CB99BDA066EF45F01014B1DE1A25A486EDE2E2040D5:1:D07A853602D6, got E71BB814DB83AB4C207CF9900CDD9FEA70A21231B7074F216BEB399B975A2999:1:5095D01FCED8

goroutine 2070 [running]:
github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).poolRoutine(0xc0000ed180)
	/home/runner/work/cosmos-consensus/cosmos-consensus/blockchain/v0/reactor.go:350 +0x1359
created by github.com/tendermint/tendermint/blockchain/v0.(*BlockchainReactor).OnStart
	/home/runner/work/cosmos-consensus/cosmos-consensus/blockchain/v0/reactor.go:118 +0x84
FAIL	github.com/tendermint/tendermint/blockchain/v0	5.361s
```