### PR TITLE
remove redundant log

### DIFF
--- a/p2p/switch.go
+++ b/p2p/switch.go
@@ -331,9 +331,6 @@ func (sw *Switch) Peers() IPeerSet {
 // TODO: make record depending on reason.
 func (sw *Switch) StopPeerForError(peer Peer, reason interface{}) {
 	sw.Logger.Error("Stopping peer for error", "peer", peer, "err", reason)
-	defer func() {
-		sw.Logger.Error("Finished stopping peer for error", "peer", peer, "err", reason)
-	}()
 	sw.stopAndRemovePeer(peer, reason)
 
 	if peer.IsPersistent() {


### PR DESCRIPTION
It seems that this does trigger when locally testing. It didn't before, so it may have changed with the 0.33 merge