### PR TITLE
Add check/reject for tx strictness

### DIFF
--- a/consensus/byzantine_test.go
+++ b/consensus/byzantine_test.go
@@ -60,7 +60,7 @@ func TestByzantine(t *testing.T) {
 					byzantineDecideProposalFunc(t, height, round, css[j], switches[j])
 				}
 			}(i)
-			css[i].doPrevote = func(height int64, round int) {}
+			css[i].doPrevote = func(height int64, round int)(bool) {return true}
 		}
 
 		eventBus := css[i].eventBus

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -134,7 +134,7 @@ type State struct {
 
 	// some functions can be overwritten for testing
 	decideProposal func(height int64, round int)
-	doPrevote      func(height int64, round int)
+	doPrevote      func(height int64, round int) bool
 	setProposal    func(proposal *types.Proposal) error
 
 	// closed when we finish shutting down
@@ -1315,7 +1315,9 @@ func (cs *State) enterPrevote(height int64, round int) {
 	// (so we have more time to try and collect +2/3 prevotes for a single block)
 }
 
-func (cs *State) defaultDoPrevote(height int64, round int) {
+// Verify the proposed block meets the protocol requirements, and if so prevote it.
+// if not, prevote nil. Return true if the proposed block is good
+func (cs *State) defaultDoPrevote(height int64, round int) bool {
 	logger := cs.Logger.With("height", height, "round", round)
 
 	timer := tmtimer.NewFunctionTimer(50, "defaultDoPrevote", cs.Logger)
@@ -1325,21 +1327,21 @@ func (cs *State) defaultDoPrevote(height int64, round int) {
 	if cs.LockedBlock != nil {
 		logger.Info("enterPrevote: Block was locked")
 		cs.signAddVote(types.PrevoteType, cs.LockedBlock.Hash(), cs.LockedBlockParts.Header())
-		return
+		return true
 	}
 
 	// If ProposalBlock is nil, prevote nil.
 	if cs.ProposalBlock == nil {
 		logger.Info("enterPrevote: ProposalBlock is nil")
 		cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{})
-		return
+		return false
 	}
 
 	// Check block entropy (note this can be empty in fallback mode which is fine)
 	if !cs.ProposalBlock.Header.Entropy.Equal(&cs.getEntropy(height).Entropy) {
 		logger.Error(fmt.Sprintf("enterPrevote: ProposalBlock has invalid entropy. Note: enabled: %v entropy: %v", cs.getEntropy(height).Enabled, cs.ProposalBlock.Header.Entropy))
 		cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{})
-		return
+		return false
 	}
 
 	// Verify if we are in fallback and strict tx filtering that the block has only
@@ -1347,7 +1349,7 @@ func (cs *State) defaultDoPrevote(height int64, round int) {
 	if cs.strictFiltering && !cs.getEntropy(height).Enabled && !allDKGTxs(&cs.ProposalBlock.Data.Txs) {
 		logger.Error(fmt.Sprintf("enterPrevote: ProposalBlock fails the strict tx check "))
 		cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{})
-		return
+		return false
 	}
 
 	// Validate proposal block
@@ -1356,7 +1358,7 @@ func (cs *State) defaultDoPrevote(height int64, round int) {
 		// ProposalBlock is invalid, prevote nil.
 		logger.Error("enterPrevote: ProposalBlock is invalid", "err", err)
 		cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{})
-		return
+		return false
 	}
 
 	// Prevote cs.ProposalBlock
@@ -1364,6 +1366,7 @@ func (cs *State) defaultDoPrevote(height int64, round int) {
 	// and the proposal block parts are validated as they are received (against the merkle hash in the proposal)
 	logger.Info("enterPrevote: ProposalBlock is valid")
 	cs.signAddVote(types.PrevoteType, cs.ProposalBlock.Hash(), cs.ProposalBlockParts.Header())
+	return true
 }
 
 // Enter: any +2/3 prevotes at next round.

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1688,6 +1688,61 @@ func TestStateOutputVoteStats(t *testing.T) {
 
 }
 
+func TestBlockAcceptance(t *testing.T) {
+	cs1, _ := randState(4)
+	height, round := cs1.Height, cs1.Round
+
+	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
+	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
+
+	startTestRound(cs1, height, round)
+
+	// Wait for new round so proposer is set.
+	ensureNewRound(newRoundCh, height, round)
+
+	// Commit a block and ensure proposer for the next height is correct.
+	prop := cs1.GetRoundState().Validators.GetProposer()
+	address := cs1.privValidator.GetPubKey().Address()
+	if !bytes.Equal(prop.Address, address) {
+		t.Fatalf("expected proposer to be validator %d. Got %X", 0, prop.Address)
+	}
+
+	// Wait for complete proposal.
+	ensureNewProposal(proposalCh, height, round)
+
+	assert.True(t, cs1.doPrevote(height, round) == true, "Failed to verify that the prevote will succeed normally")
+}
+
+func TestBlockRejectionWhenStrictFiltering(t *testing.T) {
+	cs1, _ := randState(4)
+	height, round := cs1.Height, cs1.Round
+
+	newRoundCh := subscribe(cs1.eventBus, types.EventQueryNewRound)
+	proposalCh := subscribe(cs1.eventBus, types.EventQueryCompleteProposal)
+
+	startTestRound(cs1, height, round)
+
+	// Wait for new round so proposer is set.
+	ensureNewRound(newRoundCh, height, round)
+
+	// Commit a block and ensure proposer for the next height is correct.
+	prop := cs1.GetRoundState().Validators.GetProposer()
+	address := cs1.privValidator.GetPubKey().Address()
+	if !bytes.Equal(prop.Address, address) {
+		t.Fatalf("expected proposer to be validator %d. Got %X", 0, prop.Address)
+	}
+
+	// Wait for complete proposal.
+	ensureNewProposal(proposalCh, height, round)
+
+	// Modify the consensus state to have strict filtering, and put a non-dkg TX into the block
+	cs1.strictFiltering = true
+	var nonDKGTx []types.Tx = []types.Tx{[]byte("xxx")}
+	cs1.ProposalBlock.Data.Txs = types.Txs(nonDKGTx)
+
+	assert.True(t, cs1.doPrevote(height, round) == true, "Failed to verify that the prevote will fail when it should be strict")
+}
+
 // subscribe subscribes test client to the given query and returns a channel with cap = 1.
 func subscribe(eventBus *types.EventBus, q tmpubsub.Query) <-chan tmpubsub.Message {
 	sub, err := eventBus.Subscribe(context.Background(), testSubscriber, q)

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -1740,7 +1740,7 @@ func TestBlockRejectionWhenStrictFiltering(t *testing.T) {
 	var nonDKGTx []types.Tx = []types.Tx{[]byte("xxx")}
 	cs1.ProposalBlock.Data.Txs = types.Txs(nonDKGTx)
 
-	assert.True(t, cs1.doPrevote(height, round) == true, "Failed to verify that the prevote will fail when it should be strict")
+	assert.True(t, cs1.doPrevote(height, round) == false, "Failed to verify that the prevote will fail when it should be strict")
 }
 
 // subscribe subscribes test client to the given query and returns a channel with cap = 1.


### PR DESCRIPTION
As in title. I have added a test for this case, I will need to flesh it out further since it is a little hacky and doesn't cover the other cases in doPrevote that should be tested it looks like.

When I do this slot protocol, I will add a test that the block is rejected if the slot protocol is unhappy, plus a test that the block is rejected if it does/nt contain entropy in line with the entropy generator