### PR TITLE
catch possible segv when accessing front of queue in mempool

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -500,7 +500,7 @@ func (mem *CListMempool) GetNewTxs(peerID uint16, max int) (ret []*types.Tx) {
 		mem.peerPointers[peerID] = peerPointer{mem.txs.Front(), make([]*clist.CElement, 0)}
 		front := mem.txs.Front()
 		if front == nil {
-			mem.logger.Error("Error closing WAL", "err", err)
+			mem.logger.Error("Front of mempool was empty when it shouldn't be")
 			return
 		}
 		ret = append(ret, &front.Value.(*mempoolTx).tx) // corner case where we want this + next

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -486,13 +486,13 @@ func (mem *CListMempool) TxsAvailable() <-chan struct{} {
 // forward references in the list.
 func (mem *CListMempool) GetNewTxs(peerID uint16, max int) (ret []*types.Tx) {
 
-	// Lock here protects peer pointers map and front of clist
-	mem.proxyMtx.Lock()
-
 	// There isn't any new Txs
 	if mem.txs.Len() == 0 {
 		return
 	}
+
+	// Lock here protects peer pointers map and front of clist
+	mem.proxyMtx.Lock()
 
 	// Does this peer already exist in the map? If not, create and
 	// point to the front of the list
@@ -500,7 +500,8 @@ func (mem *CListMempool) GetNewTxs(peerID uint16, max int) (ret []*types.Tx) {
 		mem.peerPointers[peerID] = peerPointer{mem.txs.Front(), make([]*clist.CElement, 0)}
 		front := mem.txs.Front()
 		if front == nil {
-			panic("Front of clist in mempool is nil!")
+			mem.logger.Error("Error closing WAL", "err", err)
+			return
 		}
 		ret = append(ret, &front.Value.(*mempoolTx).tx) // corner case where we want this + next
 	}


### PR DESCRIPTION
I saw this in the end to end test:

```panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0xccebae]

goroutine 165 [running]:
github.com/tendermint/tendermint/mempool.(*CListMempool).GetNewTxs(0xc0003409c0, 0x2, 0x64, 0x7fb7917f4308, 0xc000aff380, 0x1)
	/home/runner/work/cosmos-consensus/cosmos-consensus/mempool/clist_mempool.go:501 +0x76e
github.com/tendermint/tendermint/mempool.(*Reactor).broadcastTxRoutine(0xc000117b90, 0x1370020, 0xc000440d80)
	/home/runner/work/cosmos-consensus/cosmos-consensus/mempool/reactor.go:239 +0x3da
created by github.com/tendermint/tendermint/mempool.(*Reactor).AddPeer
	/home/runner/work/cosmos-consensus/cosmos-consensus/mempool/reactor.go:151 +0x53
```

So I think this should fix it, or at least narrow it down if it happens again