### PR TITLE
Introduce slot protocol enforcer

### DIFF
--- a/beacon/common_test.go
+++ b/beacon/common_test.go
@@ -78,7 +78,7 @@ func newStateWithConfigAndBlockStore(
 	proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 
 	// Make Mempool
-	mempool := mempool.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0)
+	mempool := mempool.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0, nil)
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()
 	}

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -143,7 +143,7 @@ func NewDistributedKeyGeneration(beaconConfig *cfg.BeaconConfig, chain string,
 	}
 	dkg.BaseService = *service.NewBaseService(nil, "DKG", dkg)
 
-	if !dkg.index() < 0 {
+	if dkg.index() >= 0 {
 		dkg.beaconService = NewBeaconSetupService(uint(len(dkg.validators.Validators)), uint(dkg.threshold), uint(dkg.index()))
 	}
 	// Set validator address to index

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -404,10 +404,14 @@ func (dkg *DistributedKeyGeneration) checkMsg(msg *types.DKGMessage, index int, 
 // Validate that the message is a valid one to be taking part in the DKG in general (not necessarily to us)
 func (dkg *DistributedKeyGeneration) validateMessage(msg *types.DKGMessage, index int, val *types.Validator) error {
 
-	if msg.Type >= DKGTypeCount {
+	// If it is a signed message from us, then assume it is correct since we are not malicious
+		if dkg.msgFromSelf(msg, index) && val.PubKey.VerifyBytes(msg.SignBytes(dkg.chainID), msg.Signature) {
+			return nil
+		}
+
+	if msg.Type >= types.DKGTypeCount {
 		return fmt.Errorf(fmt.Sprintf("checkMsg: msg failed as type out of bounds! %v", msg.Type))
 	}
-
 	if err := msg.ValidateBasic(); err != nil {
 		return fmt.Errorf("checkMsg: msg failed ValidateBasic err %v", err)
 	}

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -374,9 +374,14 @@ func (dkg *DistributedKeyGeneration) msgFromSelf(msg *types.DKGMessage, index in
 func (dkg *DistributedKeyGeneration) validateMessage(msg *types.DKGMessage, index int, val *types.Validator) (types.DKGMessageStatus, error) {
 
 	// If it is a signed message from us, then assume it is correct since we are not malicious
-		if dkg.msgFromSelf(msg, index) && val.PubKey.VerifyBytes(msg.SignBytes(dkg.chainID), msg.Signature) {
+	// otherwise, invalid!
+	if dkg.msgFromSelf(msg, index) {
+		if val.PubKey.VerifyBytes(msg.SignBytes(dkg.chainID), msg.Signature) {
 			return types.OK, nil
+		} else {
+			return types.Invalid, fmt.Errorf("validateMessage: apparent message from self not signed correctly!")
 		}
+	}
 
 	// Basic checks for all DKG messages
 	if msg.Type >= types.DKGTypeCount {

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -143,10 +143,7 @@ func NewDistributedKeyGeneration(beaconConfig *cfg.BeaconConfig, chain string,
 	}
 	dkg.BaseService = *service.NewBaseService(nil, "DKG", dkg)
 
-	if dkg.index() < 0 {
-		// TODO(HUT): how can this log before it is set?
-		dkg.Logger.Debug("startNewDKG: not in validators", "height", dkg.validatorHeight)
-	} else {
+	if !dkg.index() < 0 {
 		dkg.beaconService = NewBeaconSetupService(uint(len(dkg.validators.Validators)), uint(dkg.threshold), uint(dkg.index()))
 	}
 	// Set validator address to index

--- a/beacon/dkg.go
+++ b/beacon/dkg.go
@@ -403,6 +403,11 @@ func (dkg *DistributedKeyGeneration) checkMsg(msg *types.DKGMessage, index int, 
 
 // Validate that the message is a valid one to be taking part in the DKG in general (not necessarily to us)
 func (dkg *DistributedKeyGeneration) validateMessage(msg *types.DKGMessage, index int, val *types.Validator) error {
+
+	if msg.Type >= DKGTypeCount {
+		return fmt.Errorf(fmt.Sprintf("checkMsg: msg failed as type out of bounds! %v", msg.Type))
+	}
+
 	if err := msg.ValidateBasic(); err != nil {
 		return fmt.Errorf("checkMsg: msg failed ValidateBasic err %v", err)
 	}

--- a/beacon/dkg_runner_test.go
+++ b/beacon/dkg_runner_test.go
@@ -96,13 +96,13 @@ func testDKGRunners(nVals int, nSentries int) ([]*DKGRunner, tx_extensions.Messa
 	fakeHandler := tx_extensions.NewFakeMessageHandler()
 	dkgRunners := make([]*DKGRunner, nVals+nSentries)
 	for index := 0; index < nVals; index++ {
-		dkgRunners[index] = NewDKGRunner(config, "dkg_runner_test", stateDB, privVals[index], tmnoise.NewEncryptionKey(), 0)
+		dkgRunners[index] = NewDKGRunner(config, "dkg_runner_test", stateDB, privVals[index], tmnoise.NewEncryptionKey(), 0, nil)
 		dkgRunners[index].SetLogger(logger.With("index", index))
 		dkgRunners[index].AttachMessageHandler(fakeHandler)
 	}
 	for index := 0; index < nSentries; index++ {
 		_, privVal := types.RandValidator(false, 10)
-		dkgRunners[nVals+index] = NewDKGRunner(config, "dkg_runner_test", stateDB, privVal, tmnoise.NewEncryptionKey(), 0)
+		dkgRunners[nVals+index] = NewDKGRunner(config, "dkg_runner_test", stateDB, privVal, tmnoise.NewEncryptionKey(), 0, nil)
 		dkgRunners[nVals+index].SetLogger(logger.With("index", -1))
 		dkgRunners[nVals+index].AttachMessageHandler(fakeHandler)
 	}

--- a/beacon/dkg_test.go
+++ b/beacon/dkg_test.go
@@ -144,8 +144,9 @@ func TestDKGCheckMessage(t *testing.T) {
 			msg := dkgToGenerateMsg.newDKGMessage(types.DKGDryRun, "data", nil)
 			tc.changeMsg(msg)
 			index, val := dkgToProcessMsg.validators.GetByAddress(msg.FromAddress)
-			err := dkgToProcessMsg.checkMsg(msg, index, val)
+			status, err := dkgToProcessMsg.validateMessage(msg, index, val)
 			assert.Equal(t, tc.passCheck, err == nil, "Unexpected error %v", err)
+			assert.Equal(t, status, types.OK)
 		})
 	}
 }

--- a/beacon/dkg_test.go
+++ b/beacon/dkg_test.go
@@ -327,7 +327,7 @@ func exampleDKG(nVals int) *DistributedKeyGeneration {
 	state, _ := sm.LoadStateFromDBOrGenesisDoc(stateDB, genDoc)
 	config := cfg.TestBeaconConfig()
 
-	dkg := NewDistributedKeyGeneration(config, genDoc.ChainID, privVals[0], tmnoise.NewEncryptionKey(), 8, *state.Validators, 20, 100)
+	dkg := NewDistributedKeyGeneration(config, genDoc.ChainID, privVals[0], tmnoise.NewEncryptionKey(), 8, *state.Validators, 20, 100, nil)
 	dkg.SetLogger(log.TestingLogger())
 	return dkg
 }
@@ -343,7 +343,7 @@ type testNode struct {
 func newTestNode(config *cfg.BeaconConfig, chainID string, privVal types.PrivValidator,
 	vals *types.ValidatorSet, sendDuplicates bool) *testNode {
 	node := &testNode{
-		dkg:          NewDistributedKeyGeneration(config, chainID, privVal, tmnoise.NewEncryptionKey(), 8, *vals, 20, 100),
+		dkg:          NewDistributedKeyGeneration(config, chainID, privVal, tmnoise.NewEncryptionKey(), 8, *vals, 20, 100, nil),
 		currentMsgs:  make([]*types.DKGMessage, 0),
 		nextMsgs:     make([]*types.DKGMessage, 0),
 		failures:     make([]dkgFailure, 0),

--- a/beacon/slot_protocol_enforcer.go
+++ b/beacon/slot_protocol_enforcer.go
@@ -1,0 +1,204 @@
+package beacon
+
+import (
+	"fmt"
+	"sync"
+	"github.com/tendermint/tendermint/libs/log"
+	"github.com/tendermint/tendermint/p2p"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/tx_extensions"
+)
+
+type messageEnum int
+
+const (
+	messageOK messageEnum = iota
+	messageEarly
+	messageInvalid
+)
+
+// The slot protocol enforcer avoids there being duplicate or phony DKG messages in the mempool/gossip.
+
+// DKG messages are unique, and there is a finite number there should be per dkg attempt. The slot protocol enforcer
+// sits in front of the mempool and blocks bad DKG messages from going in.
+// It also verifies whether a block is invalid due to containing phony DKG Txs
+// This means it must check whether reaped txs would invalidate a block, and remove Txs from the mempool that are
+// now stale
+//
+// Should be attached to: dkg, the mempool, and the consensus state. If it is nill it always
+// allows Txs to pass through
+type SlotProtocolEnforcer struct {
+	//running                  bool
+	//currentValidators        types.ValidatorSet
+	//currentDKGID             int64
+	//currentDKGIteration      int64
+	activeDKG                *DistributedKeyGeneration
+	alreadySeenMsgs          map[string]struct{} // Txs seen going into the mempool
+	/*alreadyCommittedMsgs     map[string]interface{} // Txs seen in a block*/
+	pendingTxs               []*pendingTx
+	cbWhenUpdated            func([]byte, uint16, p2p.ID, *abci.Response)
+	logger                   log.Logger
+	mtx                      sync.Mutex
+}
+
+func NewSlotProtocolEnforcer() *SlotProtocolEnforcer{
+	return &SlotProtocolEnforcer{
+	alreadySeenMsgs     : make(map[string]struct{}),
+	pendingTxs          : make([]*pendingTx, 0),
+	cbWhenUpdated       : nil,
+	logger              : log.NewNopLogger(),
+	}
+}
+
+// Function to call when there is a new dkg enabling the stored Txs to be
+// verified
+func (sp *SlotProtocolEnforcer) SetCbWhenUpdated(fn func([]byte, uint16, p2p.ID, *abci.Response)) {
+	sp.mtx.Lock()
+	defer sp.mtx.Unlock()
+	sp.cbWhenUpdated = fn
+}
+
+// Notify the enforcer that a new DKG has started. Since the enforcer is
+// only notified when it starts and not finishes there is a slight inefficiency
+// in that valid but stale messages could be included
+// It needs to be notified on start since we do not know the validator set
+func (sp *SlotProtocolEnforcer) UpdateDKG(dkg *DistributedKeyGeneration) {
+
+	if sp == nil {
+		return
+	}
+
+	sp.mtx.Lock()
+	sp.activeDKG = dkg
+	sp.alreadySeenMsgs      = make(map[string]struct{}, 0)
+
+	pendingTxsCopy       := sp.pendingTxs
+	sp.pendingTxs        = make([]*pendingTx, 0)
+	sp.mtx.Unlock()
+
+	if sp.cbWhenUpdated == nil {
+		sp.logger.Error(fmt.Sprintf("Cb for slot protocol enforcer is nil! dkgID: %v", dkg.dkgID))
+		return
+	}
+
+	// All the txs which were potentially good we now effectively attempt to re-add
+	// to the mempool. Note this needs to not have the lock since it will once again check the
+	// slot protocol enforcer
+	for _, pending := range pendingTxsCopy {
+		sp.cbWhenUpdated(pending.tx, pending.peerID, pending.peerP2PID, pending.res)
+	}
+
+	sp.logger.Error(fmt.Sprintf("Updated with new DKG ID %v\n", dkg.dkgID))
+}
+
+// This function must be called on ALL transactions that would be added to the mempool. Normal txs
+// are ok, dkg txs will be added if it is known they are ok
+func (sp *SlotProtocolEnforcer) ShouldAdd(tx []byte, peerID uint16, peerP2PID p2p.ID, res *abci.Response) (bool) {
+	sp.mtx.Lock()
+	defer sp.mtx.Unlock()
+
+	// If nil pointer always return true
+	if sp == nil {
+		return true
+	}
+
+	// Always allow normal txs through
+	if !tx_extensions.IsDKGRelated(tx) {
+		return true
+	}
+
+	// if there is a race, go ahead and add all dkg txs to the pending queue
+	if sp.activeDKG == nil {
+		sp.logger.Error("Adding DKG Txs to the mempool with incomplete info about dkg")
+		sp.pendingTxs = append(sp.pendingTxs, &pendingTx{tx, peerID, peerP2PID, res})
+		return false
+	}
+
+	status := sp.messageStatus(tx)
+
+	switch status {
+	case messageOK:
+		return true
+
+	case messageEarly:
+		sp.logger.Error("Adding DKG Txs to the mempool with early info about dkg")
+		sp.pendingTxs = append(sp.pendingTxs, &pendingTx{tx, peerID, peerP2PID, res})
+		return false
+
+	case messageInvalid:
+		sp.logger.Error("Found invalid DKG Tx!")
+		return false
+
+	default:
+		panic(fmt.Sprintf("Invalid enum received in slot protocol\n"))
+		return false
+	}
+}
+
+// Given a known dkg tx, is it valid for this dkg, or the next, or not at all
+func (sp *SlotProtocolEnforcer) messageStatus(tx []byte) (messageEnum) {
+
+	dkgMessage, err := tx_extensions.FromBytes(tx)
+
+	if err != nil {
+		sp.logger.Error("Error when recieveing dkg message to mempool", err)
+	}
+
+	if err = dkgMessage.ValidateBasic(); err != nil {
+		sp.logger.Error("Invalid DKG message recieved. ", err)
+		return messageInvalid
+	}
+
+	// All the possible valid options for its position in the dkg slots
+	messageWithinDKG       := dkgMessage.DKGID == sp.activeDKG.dkgID && dkgMessage.DKGIteration == sp.activeDKG.dkgIteration
+	messageNextIteration   := dkgMessage.DKGID == sp.activeDKG.dkgID && dkgMessage.DKGIteration == sp.activeDKG.dkgIteration + 1
+	messageNextDKG         := dkgMessage.DKGID == sp.activeDKG.dkgID + 1 && dkgMessage.DKGIteration == 0
+
+	if !messageWithinDKG && !messageNextIteration && !messageNextDKG {
+		sp.logger.Error(fmt.Sprintf("Error when recieveing dkg message to mempool. Out of bounds: %v %v", dkgMessage.DKGID, dkgMessage.DKGIteration))
+		return messageInvalid
+	}
+
+	// If the message is in the next iteration we will need to wait to verify it
+	if messageNextIteration || messageNextDKG {
+		return messageEarly
+	}
+
+	index, val := sp.activeDKG.validators.GetByAddress(dkgMessage.FromAddress)
+	index2, _ := sp.activeDKG.validators.GetByAddress(dkgMessage.ToAddress)
+
+	// Check whether we have seen this message combo before, regardless of whether it is valid.
+	// Note, data is ignored, the signer has one attempt to put what they desire there.
+	messageUniqueString := fmt.Sprintf("%v%v%v%v%v%v", index, index2, dkgMessage.DKGID, dkgMessage.DKGIteration, dkgMessage.DKGID, dkgMessage.Type)
+
+	if _, exists := sp.alreadySeenMsgs[messageUniqueString]; exists {
+		return messageInvalid
+	}
+
+	// Otherwise, we are able to determine whether it is valid
+	// using the DKG
+	if err := sp.activeDKG.checkMsg(dkgMessage, index, val); err != nil {
+		sp.logger.Debug("SlotProtocolEnforcer: message staus", "from", dkgMessage.FromAddress, "err", err)
+		return messageInvalid
+	}
+
+	// Since it is valid, add it to the already seen cache
+	sp.alreadySeenMsgs[messageUniqueString] = struct{}{}
+	return messageOK
+}
+
+
+// SetLogger sets the Logger.
+func (sp *SlotProtocolEnforcer) SetLogger(l log.Logger) {
+	sp.logger = l
+}
+
+// This is a TX which we would like to add to the mempool
+// but do not yet know if it is valid since it belongs to a
+// DKG which starts on the next block
+type pendingTx struct {
+	tx        []byte
+	peerID    uint16
+	peerP2PID p2p.ID
+	res       *abci.Response
+}

--- a/beacon/slot_protocol_enforcer.go
+++ b/beacon/slot_protocol_enforcer.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/tx_extensions"
 )
@@ -168,7 +169,7 @@ func (sp *SlotProtocolEnforcer) messageStatus(tx []byte) (messageEnum) {
 
 	// Otherwise, we are able to determine whether it is valid
 	// using the DKG
-	if err := sp.activeDKG.validateMessage(dkgMessage, index, val); err != nil {
+	if status, err := sp.activeDKG.validateMessage(dkgMessage, index, val); status == types.Invalid {
 		sp.logger.Error("SlotProtocolEnforcer: message staus", "from", dkgMessage.FromAddress, "err", err)
 		return messageInvalid
 	}

--- a/beacon/slot_protocol_enforcer.go
+++ b/beacon/slot_protocol_enforcer.go
@@ -159,7 +159,7 @@ func (sp *SlotProtocolEnforcer) messageStatus(tx []byte) (messageEnum) {
 
 	// Check whether we have seen this message combo before, regardless of whether it is valid.
 	// Note, data is ignored, the signer has one attempt to put what they desire there.
-	messageUniqueString := fmt.Sprintf("%v%v%v%v%v%v", index, index2, dkgMessage.DKGID, dkgMessage.DKGIteration, dkgMessage.DKGID, dkgMessage.Type)
+	messageUniqueString := fmt.Sprintf("%v%v%v%v%v", index, index2, dkgMessage.DKGID, dkgMessage.DKGIteration, dkgMessage.Type)
 
 	if _, exists := sp.alreadySeenMsgs[messageUniqueString]; exists {
 		sp.logger.Error("already exists")

--- a/beacon/slot_protocol_enforcer_test.go
+++ b/beacon/slot_protocol_enforcer_test.go
@@ -1,0 +1,114 @@
+package beacon
+
+import (
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/tx_extensions"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tendermint/tendermint/types"
+	"github.com/tendermint/tendermint/p2p"
+)
+
+// Set up a DKG and add it to a slot protocol for tests
+func SlotProtocolSetup() (sp *SlotProtocolEnforcer, dkg *DistributedKeyGeneration) {
+	sp = NewSlotProtocolEnforcer()
+	dkg = exampleDKG(4)
+	sp.UpdateDKG(dkg)
+
+	return
+}
+
+// Create a random Tx, the slot protocol should allow this
+func TestSlotProtocolAllowsNormal(t *testing.T) {
+
+	sp, _ := SlotProtocolSetup()
+	assert.True(t, sp.ShouldAdd([]byte("abc"), 0, p2p.ID("0"), nil))
+}
+
+// Create a valid dkg message, this should be allowed, one time only
+func TestSlotProtocolAllowsDKGOneTimeOnly(t *testing.T) {
+
+	sp, dkg := SlotProtocolSetup()
+
+	msg := dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+
+	msgAsBytes := tx_extensions.AsBytes(msg)
+
+	assert.True(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+}
+
+// Create an invalid dkg message, this should not be allowed
+func TestSlotProtocolRejectsInvalid(t *testing.T) {
+
+	sp, dkg := SlotProtocolSetup()
+
+	msg := dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.Type = 999
+
+	msgAsBytes := tx_extensions.AsBytes(msg)
+
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+}
+
+// Check that dkg messages that are too far in the future or too old
+// are rejected
+func TestSlotProtocolAllowsNormalOneTimeOnlyxxy(t *testing.T) {
+
+	sp, dkg := SlotProtocolSetup()
+
+	// Iteration is too far ahead
+	msg := dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.DKGIteration = msg.DKGIteration + 2
+
+	msgAsBytes := tx_extensions.AsBytes(msg)
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+
+	// Iteration is too far behind
+	msg = dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.DKGIteration = msg.DKGIteration - 1
+
+	msgAsBytes = tx_extensions.AsBytes(msg)
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+
+	// ID is too far ahead
+	msg = dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.DKGID = msg.DKGID + 2
+
+	msgAsBytes = tx_extensions.AsBytes(msg)
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+
+	// ID is too far behind
+	msg = dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.DKGID = msg.DKGID - 1
+
+	msgAsBytes = tx_extensions.AsBytes(msg)
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+}
+
+// Check that messages that are slightly too early are rejected, but will still be checked/added later
+func TestSlotProtocolAllowsNormalOneTimeOnlyxxybb(t *testing.T) {
+	sp, dkg := SlotProtocolSetup()
+
+	// Iteration is slightly too early
+	msg := dkg.newDKGMessage(types.DKGDryRun, "data", nil)
+	msg.DKGIteration = msg.DKGIteration + 1
+
+	msgAsBytes := tx_extensions.AsBytes(msg)
+	assert.False(t, sp.ShouldAdd(msgAsBytes, 0, p2p.ID("0"), nil))
+
+	callbackTriggered := false
+
+	cb := func([]byte, uint16, p2p.ID, *abci.Response) {
+		callbackTriggered = true
+	}
+
+	sp.SetCbWhenUpdated(cb)
+
+	// Doesn't matter that we update with the same dkg - messages should
+	// always be rechecked (callback triggered)
+	sp.UpdateDKG(dkg)
+
+	assert.True(t, callbackTriggered)
+}

--- a/consensus/common_test.go
+++ b/consensus/common_test.go
@@ -344,7 +344,7 @@ func newStateWithConfigAndBlockStore(
 	proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 
 	// Make Mempool
-	mempool := mempl.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0)
+	mempool := mempl.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0, nil)
 	mempool.SetLogger(log.TestingLogger().With("module", "mempool"))
 	if thisConfig.Consensus.WaitForTxs() {
 		mempool.EnableTxsAvailable()

--- a/consensus/reactor_test.go
+++ b/consensus/reactor_test.go
@@ -145,7 +145,7 @@ func TestReactorWithEvidence(t *testing.T) {
 		proxyAppConnCon := abcicli.NewLocalClient(mtx, app)
 
 		// Make Mempool
-		mempool := mempl.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0)
+		mempool := mempl.NewCListMempool(thisConfig.Mempool, proxyAppConnMem, 0, nil)
 		mempool.SetLogger(log.TestingLogger().With("module", "mempool"))
 		if thisConfig.Consensus.WaitForTxs() {
 			mempool.EnableTxsAvailable()

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -152,9 +152,6 @@ type State struct {
 	newEntropy            map[int64]*types.ChannelEntropy
 	haveSetEntropyChannel bool
 	entropyChannel        <-chan types.ChannelEntropy
-
-	//// We need a check that blocks adhere to the slot protocol
-	//slotProtocolEnforcer *beacon.SlotProtocolEnforcer
 }
 
 // StateOption sets an optional parameter on the State.
@@ -168,26 +165,24 @@ func NewState(
 	blockStore sm.BlockStore,
 	txNotifier txNotifier,
 	evpool evidencePool,
-	//slotProtocolEnforcer *beacon.SlotProtocolEnforcer,
 	options ...StateOption,
 ) *State {
 	cs := &State{
-		config:               config,
-		blockExec:            blockExec,
-		blockStore:           blockStore,
-		txNotifier:           txNotifier,
-		peerMsgQueue:         make(chan msgInfo, msgQueueSize),
-		internalMsgQueue:     make(chan msgInfo, msgQueueSize),
-		timeoutTicker:        NewTimeoutTicker(),
-		statsMsgQueue:        make(chan msgInfo, msgQueueSize),
-		done:                 make(chan struct{}),
-		doWALCatchup:         true,
-		wal:                  nilWAL{},
-		evpool:               evpool,
-		evsw:                 tmevents.NewEventSwitch(),
-		metrics:              NopMetrics(),
-		newEntropy:           make(map[int64]*types.ChannelEntropy),
-		//slotProtocolEnforcer: slotProtocolEnforcer
+		config:           config,
+		blockExec:        blockExec,
+		blockStore:       blockStore,
+		txNotifier:       txNotifier,
+		peerMsgQueue:     make(chan msgInfo, msgQueueSize),
+		internalMsgQueue: make(chan msgInfo, msgQueueSize),
+		timeoutTicker:    NewTimeoutTicker(),
+		statsMsgQueue:    make(chan msgInfo, msgQueueSize),
+		done:             make(chan struct{}),
+		doWALCatchup:     true,
+		wal:              nilWAL{},
+		evpool:           evpool,
+		evsw:             tmevents.NewEventSwitch(),
+		metrics:          NopMetrics(),
+		newEntropy:       make(map[int64]*types.ChannelEntropy),
 	}
 	// set function defaults (may be overwritten before calling Start)
 	cs.decideProposal = cs.defaultDecideProposal
@@ -1349,13 +1344,6 @@ func (cs *State) defaultDoPrevote(height int64, round int) bool {
 		return false
 	}
 
-	//// Check against the tx slot protocol
-	//if !passesSlotProtocol(cs.slotProtocolEnforcer, &cs.ProposalBlock.Data.Txs) {
-	//	logger.Error(fmt.Sprintf("enterPrevote: ProposalBlock fails the to satisfy slot protocol!"))
-	//	cs.signAddVote(types.PrevoteType, nil, types.PartSetHeader{})
-	//	return false
-	//}
-
 	// Verify if we are in fallback and strict tx filtering that the block has only
 	// dkg TXs
 	if cs.strictFiltering && !cs.getEntropy(height).Enabled && !allDKGTxs(&cs.ProposalBlock.Data.Txs) {
@@ -2240,10 +2228,6 @@ func allDKGTxs(txs *types.Txs) bool {
 
 	return true
 }
-
-//func passesSlotProtocol(slotProtocolEnforcer *beacon.SlotProtocolEnforcer, txs *types.Txs) bool {
-//	return slotProtocolEnforcer.passesSlotProtocol(txs)
-//}
 
 //---------------------------------------------------------
 

--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -345,7 +345,7 @@ func (mem *CListMempool) reqResCb(
 			panic("recheck cursor is not nil in reqResCb")
 		}
 
-		mem.resCbFirstTime(tx, peerID, peerP2PID, res)
+		mem.ResCbFirstTime(tx, peerID, peerP2PID, res)
 
 		// update metrics
 		mem.metrics.Size.Set(float64(mem.Size()))
@@ -363,7 +363,7 @@ func isPriority(tx types.Tx) bool {
 }
 
 // Called from:
-//  - resCbFirstTime (lock not held) if tx is valid
+//  - ResCbFirstTime (lock not held) if tx is valid
 func (mem *CListMempool) addTx(memTx *mempoolTx) {
 	if isPriority(memTx.tx) {
 		e := mem.txs.PushFront(memTx)
@@ -394,7 +394,7 @@ func (mem *CListMempool) removeTx(tx types.Tx, elem *clist.CElement, removeFromC
 //
 // The case where the app checks the tx for the second and subsequent times is
 // handled by the resCbRecheck callback.
-func (mem *CListMempool) resCbFirstTime(
+func (mem *CListMempool) ResCbFirstTime(
 	tx []byte,
 	peerID uint16,
 	peerP2PID p2p.ID,
@@ -402,7 +402,7 @@ func (mem *CListMempool) resCbFirstTime(
 ) {
 
 	// Check if this Tx passes the slot protocol enforcer. If it is ambiguous, the
-	// enforcer will later call resCbFirstTime with the same arguments when it knows
+	// enforcer will later call ResCbFirstTime with the same arguments when it knows
 	if mem.slotProtocolEnforcer != nil && !mem.slotProtocolEnforcer(tx, peerID, peerP2PID, res) {
 		return
 	}
@@ -444,7 +444,7 @@ func (mem *CListMempool) resCbFirstTime(
 // callback, which is called after the app rechecked the tx.
 //
 // The case where the app checks the tx for the first time is handled by the
-// resCbFirstTime callback.
+// ResCbFirstTime callback.
 func (mem *CListMempool) resCbRecheck(req *abci.Request, res *abci.Response) {
 	switch r := res.Value.(type) {
 	case *abci.Response_CheckTx:

--- a/mempool/clist_mempool_test.go
+++ b/mempool/clist_mempool_test.go
@@ -45,7 +45,7 @@ func newMempoolWithAppAndConfig(cc proxy.ClientCreator, config *cfg.Config) (*CL
 	if err != nil {
 		panic(err)
 	}
-	mempool := NewCListMempool(config.Mempool, appConnMem, 0)
+	mempool := NewCListMempool(config.Mempool, appConnMem, 0, nil)
 	mempool.SetLogger(log.TestingLogger())
 	return mempool, func() { os.RemoveAll(config.RootDir) }
 }

--- a/node/node.go
+++ b/node/node.go
@@ -349,6 +349,8 @@ func createMempoolAndMempoolReactor(config *cfg.Config, proxyApp proxy.AppConns,
 		mempl.WithPostCheck(sm.TxPostCheck(state)),
 	)
 
+	slotProtocolEnforcer.SetCbWhenUpdated(mempool.ResCbFirstTime)
+
 	mempoolLogger := logger.With("module", "mempool")
 	mempool.SetLogger(mempoolLogger)
 

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -122,7 +122,7 @@ func TestNodeDKGFastSync(t *testing.T) {
 
 	// Create dkgRunner to run FastSync using chain from node
 	encryptionKey := tmnoise.NewEncryptionKey()
-	dkgRunner := beacon.NewDKGRunner(config.Beacon, config.ChainID(), n.stateDB, n.PrivValidator(), encryptionKey, blockHeight)
+	dkgRunner := beacon.NewDKGRunner(config.Beacon, config.ChainID(), n.stateDB, n.PrivValidator(), encryptionKey, blockHeight, nil)
 	dkgRunner.SetLogger(log.TestingLogger())
 	dkgRunner.AttachMessageHandler(n.specialTxHandler)
 	err := dkgRunner.FastSync(n.blockStore)
@@ -296,6 +296,7 @@ func TestCreateProposalBlock(t *testing.T) {
 		config.Mempool,
 		proxyApp.Mempool(),
 		state.LastBlockHeight,
+		nil,
 		mempl.WithMetrics(memplMetrics),
 		mempl.WithPreCheck(sm.TxPreCheck(state)),
 		mempl.WithPostCheck(sm.TxPostCheck(state)),

--- a/types/dkg_messages.go
+++ b/types/dkg_messages.go
@@ -21,16 +21,19 @@ const (
 	DKGDryRun
 
 	MaxDKGDataSize = 100000 // Max value calculated for committee size of 200
+	DKGTypeCount = 9        // number of different types of DKG message, important for the slot protocol
 )
 
 // DKGMessage contains DKGData for a particular phase of the DKG
 type DKGMessage struct {
 	Type         DKGMessageType
 	FromAddress  crypto.Address
+	FromIndex    int64
 	DKGID        int64
 	DKGIteration int64
 	Data         string
 	ToAddress    crypto.Address
+	ToIndex      int64
 	Signature    []byte
 }
 

--- a/types/dkg_messages.go
+++ b/types/dkg_messages.go
@@ -28,12 +28,10 @@ const (
 type DKGMessage struct {
 	Type         DKGMessageType
 	FromAddress  crypto.Address
-	FromIndex    int64
 	DKGID        int64
 	DKGIteration int64
 	Data         string
 	ToAddress    crypto.Address
-	ToIndex      int64
 	Signature    []byte
 }
 

--- a/types/dkg_messages.go
+++ b/types/dkg_messages.go
@@ -24,6 +24,15 @@ const (
 	DKGTypeCount = 9        // number of different types of DKG message, important for the slot protocol
 )
 
+// After checking DKG messages, these are the possible options
+type DKGMessageStatus uint16
+
+const (
+	OK DKGMessageStatus = iota
+	Invalid
+	NotForUs // the message is not for us but appears valid
+)
+
 // DKGMessage contains DKGData for a particular phase of the DKG
 type DKGMessage struct {
 	Type         DKGMessageType


### PR DESCRIPTION
slot protocol enforcer: will not let dkg txs into the mempool if they are a duplicate for that dkgID, dkgIteration. 'Future' dkg messages are witheld for a short period to account for someone sending you a dkg message before you have started your dkg (and would assume it to be invalid).

To do this, in short the DKG enforcer keeps a pointer to the dkg so it can check messages against.

Blocks might still contain duplicates/stale messages, but these are not 'voted down' as I originally intended. This is as it would make it more error prone to do this: if there was a crash that made you clear your known slots, you might be submitting a block that the rest of the network considers invalid.

Unfortunetly to avoid a circular dependency the way the mempool handles it is using callbacks which is ugly. When a tx arrives that needs to be witheld, it stores the parameters of the call that would have added the TX to the mempool, and attempts an add later when the next DKG is updated.