### PR TITLE
Fix aeon length in block header

### DIFF
--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -555,7 +555,7 @@ func (entropyGenerator *EntropyGenerator) blockEntropy(height int64) types.Block
 	return *types.NewBlockEntropy(
 		entropyGenerator.entropyComputed[height],
 		height-entropyGenerator.aeon.Start,
-		entropyGenerator.aeon.End-entropyGenerator.aeon.Start,
+		entropyGenerator.aeon.End-entropyGenerator.aeon.Start + 1,
 		dkgID(entropyGenerator.aeon.validatorHeight))
 }
 


### PR DESCRIPTION
Computation of aeon length in block header was out by one as aeon.Start and aeon.End are both inclusive.