### PR TITLE
Fix flakey blockchain v1 test

### DIFF
--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -239,7 +239,9 @@ func TestFastSyncBadBlockStopsPeer(t *testing.T) {
 	defer os.RemoveAll(config.RootDir)
 	genDoc, privVals := randGenesisDoc(1, false, 30)
 
-	otherChain := newBlockchainReactorPair(log.TestingLogger(), genDoc, privVals, maxBlockHeight)
+	// Other chain needs a different valiator set
+	otherGenDoc, otherPrivVals := randGenesisDoc(1, false, 30)
+	otherChain := newBlockchainReactorPair(log.TestingLogger(), otherGenDoc, otherPrivVals, maxBlockHeight)
 	defer func() {
 		_ = otherChain.bcR.Stop()
 		_ = otherChain.conR.Stop()


### PR DESCRIPTION
Saw test failure on security branch:
```
panic: failed to process committed block (4:612B091B60A96F35C691CB84C13F2496648F9ABD55A640B06B4CC4745112C3BA): wrong Block.Header.LastBlockID.  Expected 9038EC2293882A51270A941C96F934933EBC197E03ECD1C84E2B52678F273983:1:0B78D6DA2B47, got D16C5201218C11D313CAE92D4C0C26E81F737E69AE2BC0E2AD0D677D8706F26D:1:78A9CFAC3CCC

goroutine 447 [running]:
github.com/tendermint/tendermint/blockchain/v1.(*BlockchainReactor).processBlock(0xc000b8e700, 0xc0010e3efc, 0x3)
	/home/runner/work/cosmos-consensus-security/cosmos-consensus-security/blockchain/v1/reactor.go:434 +0x764
github.com/tendermint/tendermint/blockchain/v1.(*BlockchainReactor).processBlocksRoutine(0xc000b8e700, 0xc00008e7e0)
	/home/runner/work/cosmos-consensus-security/cosmos-consensus-security/blockchain/v1/reactor.go:298 +0xb3
created by github.com/tendermint/tendermint/blockchain/v1.(*BlockchainReactor).poolRoutine
	/home/runner/work/cosmos-consensus-security/cosmos-consensus-security/blockchain/v1/reactor.go:337 +0xf6
FAIL	github.com/tendermint/tendermint/blockchain/v1	6.773s
```
Similar to blockchain v0 flakey test fix in PR #122 