### PR TITLE
metrics that have counters for the size of the txs that have arrived

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -233,6 +233,9 @@ func (mem *CListMempool) TxsWaitChan() <-chan struct{} {
 //     It gets called from another goroutine.
 // CONTRACT: Either cb will get called, or err returned.
 func (mem *CListMempool) CheckTx(tx types.Tx, cb func(*abci.Response), txInfo TxInfo) (err error) {
+
+	mem.metrics.TxsArrived.Add(1.0)
+
 	mem.proxyMtx.Lock()
 	// use defer to unlock mutex because application (*local client*) might panic
 	defer mem.proxyMtx.Unlock()
@@ -366,6 +369,9 @@ func isPriority(tx types.Tx) bool {
 // Called from:
 //  - ResCbFirstTime (lock not held) if tx is valid
 func (mem *CListMempool) addTx(memTx *mempoolTx) {
+
+	mem.metrics.TxsVerified.Add(1.0)
+
 	if isPriority(memTx.tx) {
 		e := mem.txs.PushFront(memTx)
 		mem.txsMap.Store(txKey(memTx.tx), e)

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -34,6 +34,10 @@ type Metrics struct {
 	GasReap metrics.Gauge
 	// Percentage of the mempool reaped by transaction
 	MempoolReapedPercent metrics.Gauge
+	// Number of Txs that have arrived in the mempool
+	TxsArrived metrics.Gauge
+	// Number of Txs that have been verified in the mempool
+	TxsVerified metrics.Gauge
 }
 
 // PrometheusMetrics returns Metrics build using Prometheus client library.
@@ -100,6 +104,18 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Name:      "mempool_reaped_percent",
 			Help:      "Percent of the mempool reaped for block creation",
 		}, labels).With(labelsAndValues...),
+		TxsArrived: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "txs_arrived",
+			Help:      "Number of txs that have arrived in the mempool",
+		}, labels).With(labelsAndValues...),
+		TxsVerified: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "txs_verified",
+			Help:      "Number of txs that have been verified in the mempool",
+		}, labels).With(labelsAndValues...),
 	}
 }
 
@@ -115,5 +131,7 @@ func NopMetrics() *Metrics {
 		MaxGasReap:           discard.NewGauge(),
 		GasReap:              discard.NewGauge(),
 		MempoolReapedPercent: discard.NewGauge(),
+		TxsArrived:           discard.NewGauge(),
+		TxsVerified:          discard.NewGauge(),
 	}
 }


### PR DESCRIPTION
Add counters which distuingish between txs arriving and txs verified. This will give a hint if the txs are arriving in bulk but are taking a long time to process/verify which is a bottleneck