### PR TITLE
Prevent out of order next aeon queue

### DIFF
--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -178,7 +178,12 @@ func (entropyGenerator *EntropyGenerator) LoadEntropyKeyFiles(db dbm.DB, privVal
 
 					if err1 == nil {
 						// Push the complete aeon into the entropy generator
-						aeonDetails = loadAeonDetails(aeonFile, vals, privValidator)
+						nextAeonDetails := loadAeonDetails(aeonFile, vals, privValidator)
+						if aeonDetails != nil && aeonDetails.End > nextAeonDetails.End {
+							return nil, fmt.Errorf("File %v contains out of order aeon keys. Previous aeon end %v, next aeon end %v",
+								fileToLoad, aeonDetails.End, nextAeonDetails.End)
+						}
+						aeonDetails = nextAeonDetails
 						entropyGenerator.nextAeons = append(entropyGenerator.nextAeons, aeonDetails)
 					} else {
 						return nil, errors.Wrap(err1, fmt.Sprintf("error loading validators for keyfile %v err: %v", fileToLoad, err1))

--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -77,7 +77,6 @@ func NewEntropyGenerator(bConfig *cfg.BaseConfig, beaconConfig *cfg.BeaconConfig
 		entropyShares:             make(map[int64]map[uint]types.EntropyShare),
 		lastBlockHeight:           blockHeight,
 		lastComputedEntropyHeight: -1, // value is invalid and requires last entropy to be set
-		nextAeons:                 make([]*aeonDetails, 0),
 		entropyComputed:           make(map[int64]types.ThresholdSignature),
 		baseConfig:                bConfig,
 		beaconConfig:              beaconConfig,


### PR DESCRIPTION
Bug fix from deployment. Entropy generator now checks that keys in files are not out of order, and returns error on creation of node if they are. Adding of new items of into next aeon queue also prevents older keys from being pushed onto the queue.