### PR TITLE
Allow consensus to be updated with jailed validators

### DIFF
--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -565,7 +565,7 @@ func (entropyGenerator *EntropyGenerator) checkForNewEntropy() (bool, *types.Cha
 		entropyGenerator.lastBlockHeight++
 		entropyGenerator.lastComputedEntropyHeight = entropyGenerator.lastBlockHeight
 
-		return true, types.NewChannelEntropy(height, entropyGenerator.blockEntropy(height), true, entropyGenerator.aeon.validators.Hash())
+		return true, types.NewChannelEntropy(height, entropyGenerator.blockEntropy(height), true, entropyGenerator.aeon.validators)
 	}
 	if len(entropyGenerator.entropyShares[height]) >= entropyGenerator.aeon.threshold {
 		message := string(tmhash.Sum(entropyGenerator.entropyComputed[entropyGenerator.lastComputedEntropyHeight]))
@@ -595,7 +595,7 @@ func (entropyGenerator *EntropyGenerator) checkForNewEntropy() (bool, *types.Cha
 			entropyGenerator.metrics.AvgEntropyGenTime.Set(avgTime)
 		}
 
-		return true, types.NewChannelEntropy(height, entropyGenerator.blockEntropy(height), true, entropyGenerator.aeon.validators.Hash())
+		return true, types.NewChannelEntropy(height, entropyGenerator.blockEntropy(height), true, entropyGenerator.aeon.validators)
 	}
 	return false, nil
 }

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -240,8 +240,8 @@ func TestStateBeaconProposerSelection(t *testing.T) {
 	entropyChannel := make(chan types.ChannelEntropy, 5)
 	cs1.SetEntropyChannel(entropyChannel)
 
-	entropyChannel <- *types.NewChannelEntropy(1, *types.NewBlockEntropy([]byte{0, 0, 0, 0, 1, 2, 3, 4}, 0, 100, 0), true, cs1.Validators.Hash())
-	entropyChannel <- *types.NewChannelEntropy(2, *types.NewBlockEntropy([]byte{0, 0, 0, 0, 5, 6, 7, 8}, 0, 100, 0), true, cs1.Validators.Hash())
+	entropyChannel <- *types.NewChannelEntropy(1, *types.NewBlockEntropy([]byte{0, 0, 0, 0, 1, 2, 3, 4}, 0, 100, 0), true, cs1.Validators)
+	entropyChannel <- *types.NewChannelEntropy(2, *types.NewBlockEntropy([]byte{0, 0, 0, 0, 5, 6, 7, 8}, 0, 100, 0), true, cs1.Validators)
 	entropyChannel <- *types.NewChannelEntropy(3, *types.EmptyBlockEntropy(), false, nil) // Push through extra empty entropy so consensus can 'look ahead'
 
 	// Check validators for height 1

--- a/types/entropy_share.go
+++ b/types/entropy_share.go
@@ -115,19 +115,19 @@ func (blockEntropy *BlockEntropy) StringIndented(indent string) string {
 
 // ChannelEntropy struct for sending entropy from entropy generator to consensus
 type ChannelEntropy struct {
-	Height        int64
-	Entropy       BlockEntropy
-	Enabled       bool
-	ValidatorHash []byte
+	Height     int64
+	Entropy    BlockEntropy
+	Enabled    bool
+	Validators *ValidatorSet
 }
 
 // NewChannelEntropy for constructing ChannelEntropy
-func NewChannelEntropy(height int64, entropy BlockEntropy, enabled bool, validatorHash []byte) *ChannelEntropy {
+func NewChannelEntropy(height int64, entropy BlockEntropy, enabled bool, validators *ValidatorSet) *ChannelEntropy {
 	return &ChannelEntropy{
-		Height:        height,
-		Entropy:       entropy,
-		Enabled:       enabled,
-		ValidatorHash: validatorHash,
+		Height:     height,
+		Entropy:    entropy,
+		Enabled:    enabled,
+		Validators: validators,
 	}
 }
 


### PR DESCRIPTION
Allow consensus validators to be a subset of the entropy validators so that jailed validators can be removed from the consensus validators.