### PR TITLE
Limit next aeon key queue

### DIFF
--- a/beacon/aeon_details.go
+++ b/beacon/aeon_details.go
@@ -3,6 +3,7 @@ package beacon
 import (
 	"fmt"
 	"io/ioutil"
+	"runtime"
 
 	tmos "github.com/tendermint/tendermint/libs/os"
 	"github.com/tendermint/tendermint/libs/tempfile"
@@ -111,6 +112,11 @@ func newAeonDetails(newPrivValidator types.PrivValidator, valHeight int64, id in
 		Start:           startHeight,
 		End:             endHeight,
 	}
+
+	runtime.SetFinalizer(ad,
+		func(ad *aeonDetails) {
+			DeleteBaseAeon(ad.aeonExecUnit)
+		})
 
 	return ad, nil
 }

--- a/beacon/entropy_generator.go
+++ b/beacon/entropy_generator.go
@@ -22,6 +22,7 @@ import (
 const (
 	// History length of entropy to keep in number of blocks
 	entropyHistoryLength = 10
+	maxNextAeons         = 5
 )
 
 // EntropyGenerator holds DKG keys for computing entropy and computes entropy shares
@@ -217,6 +218,11 @@ func (entropyGenerator *EntropyGenerator) SetNextAeonDetails(aeon *aeonDetails) 
 		entropyGenerator.Logger.Error(fmt.Sprintf("SetNextAeonsDetails: received aeon end %v less than aeon end from last element in queue %v",
 			aeon.End, previousAeon.End))
 		return
+	}
+
+	// If over max number of keys pop of the oldest one
+	if len(entropyGenerator.nextAeons) > maxNextAeons {
+		entropyGenerator.nextAeons = entropyGenerator.nextAeons[1:len(entropyGenerator.nextAeons)]
 	}
 	entropyGenerator.nextAeons = append(entropyGenerator.nextAeons, aeon)
 


### PR DESCRIPTION
- Impose a limit on the number of next aeon keys since in normal operation (not during syncing) the dkg is only computed one ahead of the current aeon. 
- Add finaliser to free C++ BaseAeon when aeonDetails is deleted