### PR TITLE
Revert "don't strict filter by default (#193)"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1066,7 +1066,7 @@ func DefaultBeaconConfig() *BeaconConfig {
 		EntropyChannelCapacity:      3,
 		ComputeEntropySleepDuration: 50 * time.Millisecond,
 		RunDKG:                      true,
-		StrictTxFiltering:           false,
+		StrictTxFiltering:           true,
 	}
 }
 


### PR DESCRIPTION
This reverts commit 7c21c84f2c67f27e86dedfa60cf95473c6d91179.