### PR TITLE
Prepend validator set hash to vote

### DIFF
--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -69,7 +69,7 @@ func makeVote(
 		BlockID:          blockID,
 	}
 
-	_ = privVal.SignVote(header.ChainID, vote)
+	_ = privVal.SignVote(types.VotePrefix(header.ChainID, valset.Hash()), vote)
 
 	return vote
 }

--- a/consensus/state.go
+++ b/consensus/state.go
@@ -2316,7 +2316,7 @@ func (cs *State) signVote(
 		BlockID:          types.BlockID{Hash: hash, PartsHeader: header},
 	}
 
-	err = cs.privValidator.SignVote(cs.state.ChainID, vote)
+	err = cs.privValidator.SignVote(types.VotePrefix(cs.state.ChainID, cs.Validators.Hash()), vote)
 	return vote, err
 }
 

--- a/consensus/state_test.go
+++ b/consensus/state_test.go
@@ -892,7 +892,7 @@ func TestStateLockPOLSafety1(t *testing.T) {
 	validatePrevote(t, cs1, round, vss[0], propBlock.Hash())
 
 	// the others sign a polka but we don't see it
-	prevotes := signVotes(types.PrevoteType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), vs2, vs3, vs4)
+	prevotes := signVotes(types.PrevoteType, propBlock.Hash(), propBlock.MakePartSet(partSize).Header(), cs1.Validators.Hash(), vs2, vs3, vs4)
 
 	t.Logf("old prop hash %v", fmt.Sprintf("%X", propBlock.Hash()))
 
@@ -1007,7 +1007,7 @@ func TestStateLockPOLSafety2(t *testing.T) {
 	propBlockID0 := types.BlockID{Hash: propBlockHash0, PartsHeader: propBlockParts0.Header()}
 
 	// the others sign a polka but we don't see it
-	prevotes := signVotes(types.PrevoteType, propBlockHash0, propBlockParts0.Header(), vs2, vs3, vs4)
+	prevotes := signVotes(types.PrevoteType, propBlockHash0, propBlockParts0.Header(), cs1.Validators.Hash(), vs2, vs3, vs4)
 
 	// the block for round 1
 	prop1, propBlock1 := decideProposal(cs1, vs2, vs2.Height, vs2.Round+1)
@@ -1723,7 +1723,7 @@ func TestStateHalt1(t *testing.T) {
 	signAddVotes(cs1, types.PrecommitType, nil, types.PartSetHeader{}, vs2) // didnt receive proposal
 	signAddVotes(cs1, types.PrecommitType, propBlock.Hash(), propBlockParts.Header(), vs3)
 	// we receive this later, but vs3 might receive it earlier and with ours will go to commit!
-	precommit4 := signVote(vs4, types.PrecommitType, propBlock.Hash(), propBlockParts.Header())
+	precommit4 := signVote(vs4, types.PrecommitType, propBlock.Hash(), propBlockParts.Header(), cs1.Validators.Hash())
 
 	incrementRound(vs2, vs3, vs4)
 
@@ -1802,7 +1802,7 @@ func TestStateOutputVoteStats(t *testing.T) {
 	// create dummy peer
 	peer := p2pmock.NewPeer(nil)
 
-	vote := signVote(vss[1], types.PrecommitType, []byte("test"), types.PartSetHeader{})
+	vote := signVote(vss[1], types.PrecommitType, []byte("test"), types.PartSetHeader{}, cs.Validators.Hash())
 
 	voteMessage := &VoteMessage{vote}
 	cs.handleMsg(msgInfo{voteMessage, peer.ID()})
@@ -1816,7 +1816,7 @@ func TestStateOutputVoteStats(t *testing.T) {
 
 	// sending the vote for the bigger height
 	incrementHeight(vss[1])
-	vote = signVote(vss[1], types.PrecommitType, []byte("test"), types.PartSetHeader{})
+	vote = signVote(vss[1], types.PrecommitType, []byte("test"), types.PartSetHeader{}, cs.Validators.Hash())
 
 	cs.handleMsg(msgInfo{&VoteMessage{vote}, peer.ID()})
 

--- a/consensus/types/height_vote_set_test.go
+++ b/consensus/types/height_vote_set_test.go
@@ -24,19 +24,19 @@ func TestPeerCatchupRounds(t *testing.T) {
 
 	hvs := NewHeightVoteSet(config.ChainID(), 1, valSet)
 
-	vote999_0 := makeVoteHR(t, 1, 999, privVals, 0)
+	vote999_0 := makeVoteHR(t, 1, 999, privVals, 0, valSet)
 	added, err := hvs.AddVote(vote999_0, "peer1")
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
-	vote1000_0 := makeVoteHR(t, 1, 1000, privVals, 0)
+	vote1000_0 := makeVoteHR(t, 1, 1000, privVals, 0, valSet)
 	added, err = hvs.AddVote(vote1000_0, "peer1")
 	if !added || err != nil {
 		t.Error("Expected to successfully add vote from peer", added, err)
 	}
 
-	vote1001_0 := makeVoteHR(t, 1, 1001, privVals, 0)
+	vote1001_0 := makeVoteHR(t, 1, 1001, privVals, 0, valSet)
 	added, err = hvs.AddVote(vote1001_0, "peer1")
 	if err != ErrGotVoteFromUnwantedRound {
 		t.Errorf("expected GotVoteFromUnwantedRoundError, but got %v", err)
@@ -52,7 +52,8 @@ func TestPeerCatchupRounds(t *testing.T) {
 
 }
 
-func makeVoteHR(t *testing.T, height int64, round int, privVals []types.PrivValidator, valIndex int) *types.Vote {
+func makeVoteHR(t *testing.T, height int64, round int, privVals []types.PrivValidator, valIndex int,
+	valSet *types.ValidatorSet) *types.Vote {
 	privVal := privVals[valIndex]
 	pubKey, err := privVal.GetPubKey()
 	if err != nil {
@@ -69,7 +70,7 @@ func makeVoteHR(t *testing.T, height int64, round int, privVals []types.PrivVali
 		BlockID:          types.BlockID{Hash: []byte("fakehash"), PartsHeader: types.PartSetHeader{}},
 	}
 	chainID := config.ChainID()
-	err = privVal.SignVote(chainID, vote)
+	err = privVal.SignVote(types.VotePrefix(chainID, valSet.Hash()), vote)
 	if err != nil {
 		panic(fmt.Sprintf("Error signing vote: %v", err))
 	}

--- a/lite2/client.go
+++ b/lite2/client.go
@@ -954,7 +954,7 @@ func (c *Client) compareNewHeaderWithWitnesses(h *types.SignedHeader) error {
 			}
 
 			if !bytes.Equal(h.Hash(), altH.Hash()) {
-				if err = c.latestTrustedVals.VerifyCommitLightTrusting(c.chainID, altH.Commit.BlockID,
+				if err = c.latestTrustedVals.VerifyCommitLightTrusting(types.VotePrefix(c.chainID, h.ValidatorsHash), altH.Commit.BlockID,
 					altH.Height, altH.Commit, c.trustLevel); err != nil {
 					c.logger.Error("Witness sent us incorrect header", "err", err, "witness", witness)
 					witnessesToRemove = append(witnessesToRemove, i)

--- a/lite2/helpers_test.go
+++ b/lite2/helpers_test.go
@@ -109,7 +109,7 @@ func makeVote(header *types.Header, valset *types.ValidatorSet,
 		BlockID:          blockID,
 	}
 	// Sign it
-	signBytes := vote.SignBytes(header.ChainID)
+	signBytes := vote.SignBytes(types.VotePrefix(header.ChainID, header.ValidatorsHash))
 	// TODO Consider reworking makeVote API to return an error
 	sig, err := key.Sign(signBytes)
 	if err != nil {

--- a/lite2/verifier.go
+++ b/lite2/verifier.go
@@ -57,7 +57,7 @@ func VerifyNonAdjacent(
 	}
 
 	// Ensure that +`trustLevel` (default 1/3) or more of last trusted validators signed correctly.
-	err := trustedVals.VerifyCommitLightTrusting(chainID, untrustedHeader.Commit.BlockID, untrustedHeader.Height,
+	err := trustedVals.VerifyCommitLightTrusting(types.VotePrefix(chainID, untrustedHeader.ValidatorsHash), untrustedHeader.Commit.BlockID, untrustedHeader.Height,
 		untrustedHeader.Commit, trustLevel)
 	if err != nil {
 		switch e := err.(type) {

--- a/state/validation_test.go
+++ b/state/validation_test.go
@@ -192,9 +192,9 @@ func TestValidateBlockCommit(t *testing.T) {
 			Type:             types.PrecommitType,
 			BlockID:          blockID,
 		}
-		err = badPrivVal.SignVote(chainID, goodVote)
+		err = badPrivVal.SignVote(types.VotePrefix(chainID, state.Validators.Hash()), goodVote)
 		require.NoError(t, err, "height %d", height)
-		err = badPrivVal.SignVote(chainID, badVote)
+		err = badPrivVal.SignVote(types.VotePrefix(chainID, state.Validators.Hash()), badVote)
 		require.NoError(t, err, "height %d", height)
 
 		wrongSigsCommit = types.NewCommit(goodVote.Height, goodVote.Round,

--- a/types/test_util.go
+++ b/types/test_util.go
@@ -35,7 +35,7 @@ func MakeCommit(blockID BlockID, height int64, round int,
 }
 
 func signAddVote(privVal PrivValidator, vote *Vote, voteSet *VoteSet) (signed bool, err error) {
-	err = privVal.SignVote(voteSet.ChainID(), vote)
+	err = privVal.SignVote(VotePrefix(voteSet.ChainID(), voteSet.valSet.Hash()), vote)
 	if err != nil {
 		return false, err
 	}
@@ -65,7 +65,7 @@ func MakeVote(
 		Type:             PrecommitType,
 		BlockID:          blockID,
 	}
-	if err := privVal.SignVote(chainID, vote); err != nil {
+	if err := privVal.SignVote(VotePrefix(chainID, valSet.Hash()), vote); err != nil {
 		return nil, err
 	}
 	return vote, nil

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -655,7 +655,7 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 		val := vals.Validators[idx]
 
 		// Validate signature.
-		voteSignBytes := commit.VoteSignBytes(chainID, idx)
+		voteSignBytes := commit.VoteSignBytes(VotePrefix(chainID, vals.Hash()), idx)
 		if !val.PubKey.VerifyBytes(voteSignBytes, commitSig.Signature) {
 			return fmt.Errorf("wrong signature (#%d): %X", idx, commitSig.Signature)
 		}
@@ -713,7 +713,7 @@ func (vals *ValidatorSet) VerifyCommitLight(chainID string, blockID BlockID,
 		val := vals.Validators[idx]
 
 		// Validate signature.
-		voteSignBytes := commit.VoteSignBytes(chainID, idx)
+		voteSignBytes := commit.VoteSignBytes(VotePrefix(chainID, vals.Hash()), idx)
 		if !val.PubKey.VerifyBytes(voteSignBytes, commitSig.Signature) {
 			return fmt.Errorf("wrong signature (#%d): %X", idx, commitSig.Signature)
 		}
@@ -763,7 +763,7 @@ func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID strin
 	oldVals := vals
 
 	// Commit must be a valid commit for newSet.
-	err := newSet.VerifyCommit(chainID, blockID, height, commit)
+	err := newSet.VerifyCommit(VotePrefix(chainID, vals.Hash()), blockID, height, commit)
 	if err != nil {
 		return err
 	}
@@ -785,7 +785,7 @@ func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID strin
 		seen[oldIdx] = true
 
 		// Validate signature.
-		voteSignBytes := commit.VoteSignBytes(chainID, idx)
+		voteSignBytes := commit.VoteSignBytes(VotePrefix(chainID, vals.Hash()), idx)
 		if !val.PubKey.VerifyBytes(voteSignBytes, commitSig.Signature) {
 			return errors.Errorf("wrong signature (#%d): %X", idx, commitSig.Signature)
 		}
@@ -815,7 +815,11 @@ func (vals *ValidatorSet) VerifyFutureCommit(newSet *ValidatorSet, chainID strin
 // for this commit, but there may be some intersection.
 //
 // Panics if trustLevel is invalid.
-func (vals *ValidatorSet) VerifyCommitLightTrusting(chainID string, blockID BlockID,
+//
+// Since validators may not correspond to validator set for the commit, the vote prefix
+// consisting of the chain ID concatenated with the commit validator set hash must be
+// passed into this function
+func (vals *ValidatorSet) VerifyCommitLightTrusting(votePrefix string, blockID BlockID,
 	height int64, commit *Commit, trustLevel tmmath.Fraction) error {
 
 	// sanity check
@@ -859,7 +863,7 @@ func (vals *ValidatorSet) VerifyCommitLightTrusting(chainID string, blockID Bloc
 			seenVals[valIdx] = idx
 
 			// Validate signature.
-			voteSignBytes := commit.VoteSignBytes(chainID, idx)
+			voteSignBytes := commit.VoteSignBytes(votePrefix, idx)
 			if !val.PubKey.VerifyBytes(voteSignBytes, commitSig.Signature) {
 				return errors.Errorf("wrong signature (#%d): %X", idx, commitSig.Signature)
 			}

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -597,7 +597,7 @@ func TestValidatorSet_VerifyCommit_All(t *testing.T) {
 
 	vote := examplePrecommit()
 	vote.ValidatorAddress = pubKey.Address()
-	sig, err := privKey.Sign(vote.SignBytes(chainID))
+	sig, err := privKey.Sign(vote.SignBytes(VotePrefix(chainID, vset.Hash())))
 	assert.NoError(t, err)
 	vote.Signature = sig
 
@@ -674,7 +674,7 @@ func TestValidatorSet_VerifyCommit_CheckAllSignatures(t *testing.T) {
 
 	// malleate 4th signature
 	vote := voteSet.GetByIndex(3)
-	err = vals[3].SignVote("CentaurusA", vote)
+	err = vals[3].SignVote(VotePrefix("CentaurusA", valSet.Hash()), vote)
 	require.NoError(t, err)
 	commit.Signatures[3] = vote.CommitSig()
 
@@ -697,7 +697,7 @@ func TestValidatorSet_VerifyCommitLight_ReturnsAsSoonAsMajorityOfVotingPowerSign
 
 	// malleate 4th signature (3 signatures are enough for 2/3+)
 	vote := voteSet.GetByIndex(3)
-	err = vals[3].SignVote("CentaurusA", vote)
+	err = vals[3].SignVote(VotePrefix("CentaurusA", valSet.Hash()), vote)
 	require.NoError(t, err)
 	commit.Signatures[3] = vote.CommitSig()
 
@@ -718,11 +718,11 @@ func TestValidatorSet_VerifyCommitLightTrusting_ReturnsAsSoonAsTrustLevelOfVotin
 
 	// malleate 3rd signature (2 signatures are enough for 1/3+ trust level)
 	vote := voteSet.GetByIndex(2)
-	err = vals[2].SignVote("CentaurusA", vote)
+	err = vals[2].SignVote(VotePrefix("CentaurusA", valSet.Hash()), vote)
 	require.NoError(t, err)
 	commit.Signatures[2] = vote.CommitSig()
 
-	err = valSet.VerifyCommitLightTrusting(chainID, blockID, h, commit, tmmath.Fraction{Numerator: 1, Denominator: 3})
+	err = valSet.VerifyCommitLightTrusting(VotePrefix(chainID, valSet.Hash()), blockID, h, commit, tmmath.Fraction{Numerator: 1, Denominator: 3})
 	assert.NoError(t, err)
 }
 
@@ -1441,7 +1441,7 @@ func TestValidatorSet_VerifyCommitLightTrusting(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err = tc.valSet.VerifyCommitLightTrusting("test_chain_id", blockID, commit.Height, commit,
+		err = tc.valSet.VerifyCommitLightTrusting(VotePrefix("test_chain_id", originalValset.Hash()), blockID, commit.Height, commit,
 			tmmath.Fraction{Numerator: 1, Denominator: 3})
 		if tc.err {
 			assert.Error(t, err)

--- a/types/vote.go
+++ b/types/vote.go
@@ -216,3 +216,9 @@ func VoteFromProto(pv *tmproto.Vote) (*Vote, error) {
 
 	return vote, vote.ValidateBasic()
 }
+
+// VotePrefix returns string appended onto votes before signing consisting
+// of the chain ID and validator set hash
+func VotePrefix(chainID string, valHash []byte) string {
+	return chainID + string(valHash)
+}

--- a/types/vote_set.go
+++ b/types/vote_set.go
@@ -198,7 +198,7 @@ func (voteSet *VoteSet) addVote(vote *Vote) (added bool, err error) {
 	}
 
 	// Check signature.
-	if err := vote.Verify(voteSet.chainID, val.PubKey); err != nil {
+	if err := vote.Verify(VotePrefix(voteSet.chainID, voteSet.valSet.Hash()), val.PubKey); err != nil {
 		return false, errors.Wrapf(err, "Failed to verify vote with ChainID %s and PubKey %s", voteSet.chainID, val.PubKey)
 	}
 


### PR DESCRIPTION
- Prepend the concatenation of chain ID and validator set hash to votes before signing
- Acts as gtag in combined signature