### PR TITLE
Block vote timestamp verification

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -693,12 +693,11 @@ func (conR *Reactor) gossipVotesForHeight(
 	ps *PeerState,
 ) bool {
 
-	// If there are lastCommits to send...
-	if prs.Step == cstypes.RoundStepNewHeight {
-		if ps.PickSendVote(rs.LastCommit) {
-			logger.Debug("Picked rs.LastCommit to send")
-			return true
-		}
+	// If there are lastCommits to send then send them regardless of the step peer is in. Last commits should
+	// be gossiped until everyone has received them all or consensus moves onto the next height
+	if ps.PickSendPrecommit(rs.LastCommit) {
+		logger.Debug("Picked rs.LastCommit to send")
+		return true
 	}
 	// If there are POL prevotes to send...
 	if prs.Step <= cstypes.RoundStepPropose && prs.Round != -1 && prs.Round <= rs.Round && prs.ProposalPOLRound != -1 {

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -695,7 +695,7 @@ func (conR *Reactor) gossipVotesForHeight(
 
 	// If there are lastCommits to send then send them regardless of the step peer is in. Last commits should
 	// be gossiped until everyone has received them all or consensus moves onto the next height
-	if ps.PickSendPrecommit(rs.LastCommit) {
+	if ps.PickSendVote(rs.LastCommit) {
 		logger.Debug("Picked rs.LastCommit to send")
 		return true
 	}

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -587,7 +587,7 @@ func newEvidence(
 	deepcpVote2 := deepcpVote(vote2)
 	deepcpVote2.Signature, err = val.Key.PrivKey.Sign(deepcpVote2.SignBytes(chainID))
 	require.NoError(t, err)
-	deepcpVote.TimestampSignature, err = val.PrivKey.Sign(deecpVote2.SignTimestamp(chainID))
+	deepcpVote2.TimestampSignature, err = val.Key.PrivKey.Sign(deepcpVote2.SignTimestamp(chainID))
 	require.NoError(t, err)
 
 	return *types.NewDuplicateVoteEvidence(val.Key.PubKey, vote, deepcpVote2)

--- a/rpc/client/rpc_test.go
+++ b/rpc/client/rpc_test.go
@@ -587,6 +587,8 @@ func newEvidence(
 	deepcpVote2 := deepcpVote(vote2)
 	deepcpVote2.Signature, err = val.Key.PrivKey.Sign(deepcpVote2.SignBytes(chainID))
 	require.NoError(t, err)
+	deepcpVote.TimestampSignature, err = val.PrivKey.Sign(deecpVote2.SignTimestamp(chainID))
+	require.NoError(t, err)
 
 	return *types.NewDuplicateVoteEvidence(val.Key.PubKey, vote, deepcpVote2)
 }
@@ -614,6 +616,7 @@ func makeEvidences(
 
 	var err error
 	vote.Signature, err = val.Key.PrivKey.Sign(vote.SignBytes(chainID))
+	require.NoError(t, err)
 	vote.TimestampSignature, err = val.Key.PrivKey.Sign(vote.SignTimestamp(chainID))
 	require.NoError(t, err)
 

--- a/types/canonical.go
+++ b/types/canonical.go
@@ -40,7 +40,11 @@ type CanonicalVote struct {
 	ChainID string
 }
 
-type CanonicalTimestamp struct {
+type CanonicalVoteWithTimestamp struct {
+	Type      SignedMsgType // type alias for byte
+	Height    int64         `binary:"fixed64"`
+	Round     int64         `binary:"fixed64"`
+	BlockID   CanonicalBlockID
 	Timestamp time.Time
 	ChainID   string
 }
@@ -84,9 +88,13 @@ func CanonicalizeVote(chainID string, vote *Vote) CanonicalVote {
 	}
 }
 
-func CanonicalizeTimestamp(chainID string, timestamp time.Time) CanonicalTimestamp {
-	return CanonicalTimestamp{
-		Timestamp: timestamp,
+func CanonicalizeVoteWithTimestamp(chainID string, vote *Vote) CanonicalVoteWithTimestamp {
+	return CanonicalVoteWithTimestamp{
+		Type:      vote.Type,
+		Height:    vote.Height,
+		Round:     int64(vote.Round), // cast int->int64 to make amino encode it fixed64 (does not work for int)
+		BlockID:   CanonicalizeBlockID(vote.BlockID),
+		Timestamp: vote.Timestamp,
 		ChainID:   chainID,
 	}
 }

--- a/types/vote.go
+++ b/types/vote.go
@@ -96,7 +96,7 @@ func (vote *Vote) SignBytes(chainID string) []byte {
 }
 
 func (vote *Vote) SignTimestamp(chainID string) []byte {
-	bz, err := cdc.MarshalBinaryLengthPrefixed(CanonicalizeTimestamp(chainID, vote.Timestamp))
+	bz, err := cdc.MarshalBinaryLengthPrefixed(CanonicalizeVoteWithTimestamp(chainID, vote))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Verify timestamp in commit votes using timestamps seen locally
- Always gossip precommit messages to avoid stalling due to unseen timestamps
- Sign timestamp with vote to avoid timestamp signature being re-used to different vote message