### PR TITLE
Fix race and nil return in precommits/votes

### DIFF
--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -679,7 +679,7 @@ OUTER_LOOP:
 			sleeping = 1
 			logger.Debug("No votes to send, sleeping", "rs.Height", rs.Height, "prs.Height", prs.Height,
 				"localPV", rs.Votes.Prevotes(rs.Round).BitArray(), "peerPV", prs.Prevotes,
-				"localPC", rs.Votes.Precommits(rs.Round).BitArray(), "peerPC", prs.Precommits.BitArray(conR.conS.Validators.Size()))
+				"localPC", rs.Votes.Precommits(rs.Round).BitArray(), "peerPC", prs.Precommits.BitArray())
 		} else if sleeping == 2 {
 			// Continued sleep...
 			sleeping = 1
@@ -1208,7 +1208,7 @@ func (ps *PeerState) ensureCatchupCommitRound(height int64, round int, numValida
 	if round == ps.PRS.Round {
 		ps.PRS.CatchupCommit = ps.PRS.Precommits
 	} else {
-		ps.PRS.CatchupCommit = cstypes.NewPrecommitRecord()
+		ps.PRS.CatchupCommit = cstypes.NewPrecommitRecord(numValidators)
 	}
 }
 
@@ -1228,17 +1228,17 @@ func (ps *PeerState) ensureVoteBitArrays(height int64, numValidators int) {
 			ps.PRS.Prevotes = bits.NewBitArray(numValidators)
 		}
 		if ps.PRS.Precommits == nil {
-			ps.PRS.Precommits = cstypes.NewPrecommitRecord()
+			ps.PRS.Precommits = cstypes.NewPrecommitRecord(numValidators)
 		}
 		if ps.PRS.CatchupCommit == nil {
-			ps.PRS.CatchupCommit = cstypes.NewPrecommitRecord()
+			ps.PRS.CatchupCommit = cstypes.NewPrecommitRecord(numValidators)
 		}
 		if ps.PRS.ProposalPOL == nil {
 			ps.PRS.ProposalPOL = bits.NewBitArray(numValidators)
 		}
 	} else if ps.PRS.Height == height+1 {
 		if ps.PRS.LastCommit == nil {
-			ps.PRS.LastCommit = cstypes.NewPrecommitRecord()
+			ps.PRS.LastCommit = cstypes.NewPrecommitRecord(numValidators)
 		}
 	}
 }

--- a/consensus/timestamp_test.go
+++ b/consensus/timestamp_test.go
@@ -1,6 +1,7 @@
 package consensus
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -55,6 +56,7 @@ func TestReactorConflictingTimestamps(t *testing.T) {
 			for i := 0; i < 10; i++ {
 				timeoutWaitGroup(t, N, func(j int) {
 					<-blocksSubs[j].Out()
+					fmt.Printf("Complete block height %v index %v\n", i, j)
 				}, css)
 			}
 		})
@@ -95,7 +97,7 @@ func invalidVoteFunc(t *testing.T, height int64, round int, cs *State, sw *p2p.S
 				PartsHeader: blockPartsHeader,
 			},
 		}
-		cs.privValidator.SignVote(cs.state.ChainID, vote1)
+		cs.privValidator.SignVote(types.VotePrefix(cs.state.ChainID, cs.Validators.Hash()), vote1)
 		// vote2
 		vote2 := &types.Vote{
 			ValidatorAddress: addr,
@@ -109,7 +111,7 @@ func invalidVoteFunc(t *testing.T, height int64, round int, cs *State, sw *p2p.S
 				PartsHeader: blockPartsHeader,
 			},
 		}
-		cs.privValidator.SignVote(cs.state.ChainID, vote2)
+		cs.privValidator.SignVote(types.VotePrefix(cs.state.ChainID, cs.Validators.Hash()), vote2)
 		cs.mtx.Unlock()
 
 		peers := sw.Peers().List()

--- a/consensus/timestamp_test.go
+++ b/consensus/timestamp_test.go
@@ -27,7 +27,7 @@ func TestReactorConflictingTimestamps(t *testing.T) {
 			css, cleanup := randConsensusNet(N, "consensus_reactor_test", newMockTickerFunc(true), newCounter)
 			defer cleanup()
 
-			for i := 0; i < 4; i++ {
+			for i := 0; i < N; i++ {
 				ticker := NewTimeoutTicker()
 				ticker.SetLogger(css[i].Logger)
 				css[i].SetTimeoutTicker(ticker)

--- a/consensus/types/height_vote_set.go
+++ b/consensus/types/height_vote_set.go
@@ -135,7 +135,11 @@ func (hvs *HeightVoteSet) AddVote(vote *types.Vote, peerID p2p.ID) (added bool, 
 func (hvs *HeightVoteSet) Prevotes(round int) *types.PrevoteSet {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
-	prevotes, ok := hvs.getVoteSet(round, types.PrevoteType).(*types.PrevoteSet)
+	voteSet := hvs.getVoteSet(round, types.PrevoteType)
+	if voteSet == nil {
+		return nil
+	}
+	prevotes, ok := voteSet.(*types.PrevoteSet)
 	if !ok {
 		panic(fmt.Sprintf("Could not convert HVS.Prevotes to PrevoteSet for round %v", round))
 	}
@@ -146,7 +150,11 @@ func (hvs *HeightVoteSet) Prevotes(round int) *types.PrevoteSet {
 func (hvs *HeightVoteSet) Precommits(round int) *types.PrecommitSet {
 	hvs.mtx.Lock()
 	defer hvs.mtx.Unlock()
-	precommits, ok := hvs.getVoteSet(round, types.PrecommitType).(*types.PrecommitSet)
+	voteSet := hvs.getVoteSet(round, types.PrecommitType)
+	if voteSet == nil {
+		return nil
+	}
+	precommits, ok := voteSet.(*types.PrecommitSet)
 	if !ok {
 		panic(fmt.Sprintf("Could not convert HVS.Precommits to PrecommitSet for round %v", round))
 	}

--- a/types/precommit_set.go
+++ b/types/precommit_set.go
@@ -330,7 +330,7 @@ func (voteSet *PrecommitSet) BitArray() *bits.BitArray {
 
 func (voteSet *PrecommitSet) VotesByBlockID(blockID BlockID) []string {
 	if voteSet == nil {
-		return nil
+		return []string{}
 	}
 	voteSet.mtx.Lock()
 	defer voteSet.mtx.Unlock()
@@ -344,7 +344,7 @@ func (voteSet *PrecommitSet) VotesByBlockID(blockID BlockID) []string {
 		}
 		return votes
 	}
-	return nil
+	return []string{}
 }
 
 // GetByIndex returns all precommit votes from a validator index as a map with timestamp


### PR DESCRIPTION
- Fix failed interface conversion from return of nil interface in height vote set getPrecommit and getPrevote
- Fix race condition in getting validator set size in consensus/reactor log message. Save validator set size in creation of PrecommitRecord instead
- Fix incorrect signing of votes in timestamp test