### PR TITLE
Bug fix in commit gossip and trim commits in store

### DIFF
--- a/blockchain/v1/reactor_test.go
+++ b/blockchain/v1/reactor_test.go
@@ -116,15 +116,8 @@ func newBlockchainReactor(
 	sm.SaveState(db, state)
 
 	// let's add some blocks in
+	lastCommit := types.NewCommit(0, 1, types.BlockID{}, nil)
 	for blockHeight := int64(1); blockHeight <= maxBlockHeight; blockHeight++ {
-		lastCommit := types.NewCommit(blockHeight-1, 1, types.BlockID{}, nil)
-		if blockHeight > 1 {
-			lastBlockMeta := blockStore.LoadBlockMeta(blockHeight - 1)
-			lastBlock := blockStore.LoadBlock(blockHeight - 1)
-
-			vote := makeVote(t, &lastBlock.Header, lastBlockMeta.BlockID, state.Validators, privVals[0])
-			lastCommit = types.NewCommit(vote.Height, vote.Round, lastBlockMeta.BlockID, [][]types.CommitSig{{vote.CommitSig()}})
-		}
 
 		thisBlock := makeBlock(blockHeight, state, lastCommit)
 
@@ -135,6 +128,9 @@ func newBlockchainReactor(
 		if err != nil {
 			panic(errors.Wrap(err, "error apply block"))
 		}
+
+		vote := makeVote(t, &thisBlock.Header, blockID, state.Validators, privVals[0])
+		lastCommit = types.NewCommit(vote.Height, vote.Round, blockID, [][]types.CommitSig{{vote.CommitSig()}})
 
 		blockStore.SaveBlock(thisBlock, thisParts, lastCommit)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -316,15 +316,14 @@ func (bs *BlockStore) SaveBlock(block *types.Block, blockParts *types.PartSet, s
 				}
 			}
 			// If we do not have the commit sig with timestamp matching the one included in the block
-			// Replace with the one from the block but there will be no timestamp signature
-			// for this vote
+			// Replace with nil
 			if matchingIndex < 0 {
-				previousCommit.Signatures[index][0] = block.LastCommit.Signatures[index][0]
+				previousCommit.Signatures[index] = nil
 			} else {
 				previousCommit.Signatures[index][0] = previousCommit.Signatures[index][matchingIndex]
+				// Only keep the vote with timestamp matching the one in the block
+				previousCommit.Signatures[index] = previousCommit.Signatures[index][:1]
 			}
-			// Only keep the vote with timestamp matching the one in the block
-			previousCommit.Signatures[index] = previousCommit.Signatures[index][:1]
 		}
 
 		previousCommitBytes := cdc.MustMarshalBinaryBare(previousCommit)


### PR DESCRIPTION
- Fetch commits seen (which includes timestamp signature) rather than block commits when gossiping to peers
- When saving block at height H, trim the seen commits at height H-1 to only contain those included in the block at height H
- Fix blockchain test so that it computes seenCommit for block height 1