### PR TITLE
Benchmarking combined sigs

### DIFF
--- a/beacon/crypto_test.go
+++ b/beacon/crypto_test.go
@@ -235,6 +235,8 @@ func testAeonFromFile(filename string) mcl_cpp.BaseAeon {
 	return mcl_cpp.NewBlsAeon(filename)
 }
 
+// Benchmarks the function used to compute the public key used to verify combined signatures
+// This operation is costly due to the string to mcl conversions
 func BenchmarkCombinedPubKey(b *testing.B) {
 	nVals := 100
 
@@ -249,6 +251,7 @@ func BenchmarkCombinedPubKey(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		pubKeys := mcl_cpp.NewStringVector()
+		defer mcl_cpp.DeleteStringVector(pubKeys)
 		for i := 0; i < nVals; i++ {
 			pubKeys.Add(publicKeyStrs[i])
 		}
@@ -256,6 +259,7 @@ func BenchmarkCombinedPubKey(b *testing.B) {
 	}
 }
 
+// Benchmarks the combined signature verification function used by validators to verify blocks
 func BenchmarkVerifyCombinedSignature(b *testing.B) {
 	nVals := 100
 	signerRecord := bits.NewBitArray(nVals)

--- a/mcl_cpp/combined_sigs.cpp
+++ b/mcl_cpp/combined_sigs.cpp
@@ -27,67 +27,7 @@ namespace beacon {
 
 static const std::string COMBINED_SIG_GENERATOR  = "Fetchai Combined Signature Generator";
 
-// Constructor for combined signature should set the string to the serialisation
-// of the zero of signature element
-CombinedSignature::CombinedSignature() {
-    mcl::Signature sig;
-    combined_signature_ = sig.ToString();
-}
-
-// Adds a signature to the saved combined signature string. Returns whether the signature
-// was added or not.
-bool CombinedSignature::Add(std::string const &signature) {
-    // Get saved combined signature
-    mcl::Signature sig;
-    sig.FromString(combined_signature_);
-
-    mcl::Signature sig_to_add;
-    bool ok = sig_to_add.FromString(signature);
-    if (!ok) {
-        Log(LogLevel::ERROR, LOGGING_NAME, "Add can not deserialise signature "+signature);
-        return false;
-    }
-
-    sig.Add(sig, sig_to_add);
-    combined_signature_ = sig.ToString();
-    return true;
-}  
-
-std::string CombinedSignature::Finish() const {
-    return combined_signature_;
-}
-
-// Constructor for combined public key should set the string to the serialisation
-// of the zero of public key element
-CombinedPublicKey::CombinedPublicKey() {
-    mcl::GroupPublicKey pub_key;
-    combined_key_ = pub_key.ToString();
-}
-
-// Adds a signature to the saved combined public key string. Returns whether the public key
-// was added or not.
-bool CombinedPublicKey::Add(std::string const &public_key) {
-    // Get saved combined public key
-    mcl::GroupPublicKey pub_key;
-    pub_key.FromString(combined_key_);
-
-    mcl::GroupPublicKey pub_key_to_add;
-    bool ok = pub_key_to_add.FromString(public_key);
-    if (!ok) {
-        Log(LogLevel::ERROR, LOGGING_NAME, "Add can not deserialise public key "+public_key);
-        return false;
-    }
-
-    pub_key.Add(pub_key, pub_key_to_add);
-    combined_key_ = pub_key.ToString();
-    return true;
-}  
-
-std::string CombinedPublicKey::Finish() const {
-    return combined_key_;
-}
-    
-// GenPrivKey generates a new Bls12_381 private key
+ // GenPrivKey generates a new Bls12_381 private key
 // It uses OS randomness to generate the private key.
 std::string GenPrivKey() {
     mcl::PrivateKey new_key;
@@ -148,6 +88,33 @@ std::string Sign(std::string const &message, std::string const &private_key) {
 
     return mcl::Sign(message, priv_key).ToString();
 }
+
+std::string CombinePublicKeys(std::vector<std::string> const &pub_keys) {
+    mcl::GroupPublicKey pub_key;
+    for (auto const &key : pub_keys) {
+        mcl::GroupPublicKey val_key;
+        bool ok_key = val_key.FromString(key);
+        if (!ok_key) {
+            return "";
+        }
+        pub_key.Add(pub_key, val_key);
+    }
+    return pub_key.ToString();
+}
+
+std::string CombineSignatures(std::vector<std::string> const &sigs) {
+ mcl::Signature combined_sig;
+    for (auto const &sig : sigs) {
+        mcl::Signature val_sig;
+        bool ok_sig = val_sig.FromString(sig);
+        if (!ok_sig) {
+            return "";
+        }
+        combined_sig.Add(combined_sig, val_sig);
+    }
+    return combined_sig.ToString();
+}
+
 bool PairingVerify(std::string const &message, std::string const &sign, std::string const &public_key) {
     mcl::Signature signature;
     mcl::GroupPublicKey pub_key;
@@ -156,6 +123,27 @@ bool PairingVerify(std::string const &message, std::string const &sign, std::str
     bool ok_key = pub_key.FromString(public_key);
     if (!ok_sign || !ok_key) {
         return false;
+    }
+    mcl::SetGenerator(gen, COMBINED_SIG_GENERATOR);
+    
+    return mcl::PairingVerify(message, signature, pub_key, gen);
+}
+
+bool PairingVerifyCombinedSig(std::string const &message, std::string const &sign, std::vector<std::string> const &public_key) {
+    mcl::Signature signature;
+    mcl::GroupPublicKey pub_key;
+    mcl::GroupPublicKey gen;
+    bool ok_sign = signature.FromString(sign);
+     if (!ok_sign) {
+        return false;
+    }
+    for (auto const &key : public_key) {
+        mcl::GroupPublicKey val_key;
+        bool ok_key = val_key.FromString(key);
+        if (!ok_key) {
+            return false;
+        }
+        pub_key.Add(pub_key, val_key);
     }
     mcl::SetGenerator(gen, COMBINED_SIG_GENERATOR);
     

--- a/mcl_cpp/combined_sigs.cpp
+++ b/mcl_cpp/combined_sigs.cpp
@@ -27,7 +27,7 @@ namespace beacon {
 
 static const std::string COMBINED_SIG_GENERATOR  = "Fetchai Combined Signature Generator";
 
- // GenPrivKey generates a new Bls12_381 private key
+// GenPrivKey generates a new Bls12_381 private key
 // It uses OS randomness to generate the private key.
 std::string GenPrivKey() {
     mcl::PrivateKey new_key;

--- a/mcl_cpp/combined_sigs.cpp
+++ b/mcl_cpp/combined_sigs.cpp
@@ -89,6 +89,7 @@ std::string Sign(std::string const &message, std::string const &private_key) {
     return mcl::Sign(message, priv_key).ToString();
 }
 
+// Combines a list of public keys for verifying combined signatures
 std::string CombinePublicKeys(std::vector<std::string> const &pub_keys) {
     mcl::GroupPublicKey pub_key;
     for (auto const &key : pub_keys) {
@@ -102,8 +103,9 @@ std::string CombinePublicKeys(std::vector<std::string> const &pub_keys) {
     return pub_key.ToString();
 }
 
+// Combines a list of signatures into a combined signature
 std::string CombineSignatures(std::vector<std::string> const &sigs) {
- mcl::Signature combined_sig;
+    mcl::Signature combined_sig;
     for (auto const &sig : sigs) {
         mcl::Signature val_sig;
         bool ok_sig = val_sig.FromString(sig);
@@ -129,6 +131,8 @@ bool PairingVerify(std::string const &message, std::string const &sign, std::str
     return mcl::PairingVerify(message, signature, pub_key, gen);
 }
 
+// Verifies a combined signature by computing the combined public key from a list of public keys and computing the elliptic curve 
+// pairing
 bool PairingVerifyCombinedSig(std::string const &message, std::string const &sign, std::vector<std::string> const &public_key) {
     mcl::Signature signature;
     mcl::GroupPublicKey pub_key;

--- a/mcl_cpp/combined_sigs.hpp
+++ b/mcl_cpp/combined_sigs.hpp
@@ -25,36 +25,15 @@
 namespace fetch {
 namespace beacon {
 
-// Combined signature class for combined signatures and outputting result
-class CombinedSignature {
-public:
-    CombinedSignature();
-
-    bool Add(std::string const &signature);
-    std::string Finish() const;
-private:
-    std::string combined_signature_;
-    static constexpr char const *LOGGING_NAME = "CombinedSignatures";
-};
-
-// Aggregate public key class for combining public keys for verifying combined signatures
-class CombinedPublicKey {
-public:
-    CombinedPublicKey();
-
-    bool Add(std::string const &public_key);
-    std::string Finish() const;
-private:
-    std::string combined_key_;
-    static constexpr char const *LOGGING_NAME = "CombinedPublicKey";
-};
-
 std::string GenPrivKey();
 std::string GenPrivKeyBls(std::string const &secret); 
 std::string PubKeyFromPrivate(std::string const &private_key);
 std::pair<std::string, std::string> PubKeyFromPrivateWithPoP(std::string const &private_key);
 std::string Sign(std::string const &message, std::string const &private_key);
+std::string CombinePublicKeys(std::vector<std::string> const &pub_keys);
+std::string CombineSignatures(std::vector<std::string> const &sigs);
 bool PairingVerify(std::string const &message, std::string const &sign, std::string const &public_key);
+bool PairingVerifyCombinedSig(std::string const &message, std::string const &sign, std::vector<std::string> const &public_key);
 
 } //beacon
 } //fetch

--- a/types/block.go
+++ b/types/block.go
@@ -693,6 +693,9 @@ type Commit struct {
 
 // NewCommit returns a new Commit.
 func NewCommit(height int64, round int, blockID BlockID, commitSigs [][]CommitSig) *Commit {
+	// Computed combined signature by combining signatures for the block in order of validator
+	// index. CombinedSignature in the commit will be empty if any of the individual signatures
+	// does not correspond to the correct mcl signature type
 	sigs := mcl_cpp.NewStringVector()
 	defer mcl_cpp.DeleteStringVector(sigs)
 	for _, commitSig := range commitSigs {

--- a/types/block.go
+++ b/types/block.go
@@ -693,11 +693,12 @@ type Commit struct {
 
 // NewCommit returns a new Commit.
 func NewCommit(height int64, round int, blockID BlockID, commitSigs [][]CommitSig) *Commit {
-	combinedSig := mcl_cpp.NewCombinedSignature()
+	sigs := mcl_cpp.NewStringVector()
+	defer mcl_cpp.DeleteStringVector(sigs)
 	for _, commitSig := range commitSigs {
 		// Exclude sigs which are for nil or are absent
 		if commitSig[0].ForBlock() {
-			combinedSig.Add(string(commitSig[0].Signature))
+			sigs.Add(string(commitSig[0].Signature))
 		}
 	}
 	return &Commit{
@@ -705,7 +706,7 @@ func NewCommit(height int64, round int, blockID BlockID, commitSigs [][]CommitSi
 		Round:             round,
 		BlockID:           blockID,
 		Signatures:        commitSigs,
-		CombinedSignature: combinedSig.Finish(),
+		CombinedSignature: mcl_cpp.CombineSignatures(sigs),
 	}
 }
 

--- a/types/validator_set_test.go
+++ b/types/validator_set_test.go
@@ -1573,3 +1573,24 @@ func BenchmarkUpdates(b *testing.B) {
 		assert.NoError(b, valSetCopy.UpdateWithChangeSet(newValList))
 	}
 }
+
+func BenchmarkVerifyCommit(b *testing.B) {
+	var (
+		chainID               = "test_chain_id"
+		height                = int64(1)
+		round                 = 0
+		blockID               = makeBlockIDRandom()
+		nVals                 = 100
+		voteSet, valSet, vals = randPrecommitSet(height, round, nVals, 10)
+		commit, err           = MakeCommit(blockID, height, round, voteSet, vals, time.Now())
+	)
+
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		valSet.VerifyCommit(chainID, blockID, height, commit)
+	}
+}


### PR DESCRIPTION
- Reduce number of string to mcl type conversions to improve performance of combined signatures
- Add benchmarks for combined sig and block verification functions