### PR TITLE
Fix light client bisection benchmark

### DIFF
--- a/lite2/client_benchmark_test.go
+++ b/lite2/client_benchmark_test.go
@@ -26,25 +26,27 @@ func BenchmarkSequence(b *testing.B) {
 		benchmarkFullNode = mockp.New(GenMockNode(chainID, 1000, 100, 1, bTime))
 		genesisHeader, _  = benchmarkFullNode.SignedHeader(1)
 	)
-	c, err := lite.NewClient(
-		chainID,
-		lite.TrustOptions{
-			Period: 24 * time.Hour,
-			Height: 1,
-			Hash:   genesisHeader.Hash(),
-		},
-		benchmarkFullNode,
-		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB(), chainID),
-		lite.Logger(log.TestingLogger()),
-		lite.SequentialVerification(),
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c, err := lite.NewClient(
+			chainID,
+			lite.TrustOptions{
+				Period: 24 * time.Hour,
+				Height: 1,
+				Hash:   genesisHeader.Hash(),
+			},
+			benchmarkFullNode,
+			[]provider.Provider{benchmarkFullNode},
+			dbs.New(dbm.NewMemDB(), chainID),
+			lite.Logger(log.TestingLogger()),
+			lite.SequentialVerification(),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
 		_, err = c.VerifyHeaderAtHeight(1000, bTime.Add(1000*time.Minute))
 		if err != nil {
 			b.Fatal(err)
@@ -57,6 +59,8 @@ func BenchmarkBisection(b *testing.B) {
 		benchmarkFullNode = mockp.New(GenMockNode(chainID, 1000, 100, 1, bTime))
 		genesisHeader, _  = benchmarkFullNode.SignedHeader(1)
 	)
+	b.ResetTimer()
+
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()
 		c, err := lite.NewClient(
@@ -86,6 +90,8 @@ func BenchmarkBackwards(b *testing.B) {
 	var (
 		benchmarkFullNode = mockp.New(GenMockNode(chainID, 1000, 100, 1, bTime))
 	)
+	b.ResetTimer()
+
 	trustedHeader, _ := benchmarkFullNode.SignedHeader(0)
 	for n := 0; n < b.N; n++ {
 		b.StopTimer()

--- a/lite2/client_benchmark_test.go
+++ b/lite2/client_benchmark_test.go
@@ -57,24 +57,24 @@ func BenchmarkBisection(b *testing.B) {
 		benchmarkFullNode = mockp.New(GenMockNode(chainID, 1000, 100, 1, bTime))
 		genesisHeader, _  = benchmarkFullNode.SignedHeader(1)
 	)
-	c, err := lite.NewClient(
-		chainID,
-		lite.TrustOptions{
-			Period: 24 * time.Hour,
-			Height: 1,
-			Hash:   genesisHeader.Hash(),
-		},
-		benchmarkFullNode,
-		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB(), chainID),
-		lite.Logger(log.TestingLogger()),
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c, err := lite.NewClient(
+			chainID,
+			lite.TrustOptions{
+				Period: 24 * time.Hour,
+				Height: 1,
+				Hash:   genesisHeader.Hash(),
+			},
+			benchmarkFullNode,
+			[]provider.Provider{benchmarkFullNode},
+			dbs.New(dbm.NewMemDB(), chainID),
+			lite.Logger(log.TestingLogger()),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
 		_, err = c.VerifyHeaderAtHeight(1000, bTime.Add(1000*time.Minute))
 		if err != nil {
 			b.Fatal(err)
@@ -87,24 +87,24 @@ func BenchmarkBackwards(b *testing.B) {
 		benchmarkFullNode = mockp.New(GenMockNode(chainID, 1000, 100, 1, bTime))
 	)
 	trustedHeader, _ := benchmarkFullNode.SignedHeader(0)
-	c, err := lite.NewClient(
-		chainID,
-		lite.TrustOptions{
-			Period: 24 * time.Hour,
-			Height: trustedHeader.Height,
-			Hash:   trustedHeader.Hash(),
-		},
-		benchmarkFullNode,
-		[]provider.Provider{benchmarkFullNode},
-		dbs.New(dbm.NewMemDB(), chainID),
-		lite.Logger(log.TestingLogger()),
-	)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.ResetTimer()
-
 	for n := 0; n < b.N; n++ {
+		b.StopTimer()
+		c, err := lite.NewClient(
+			chainID,
+			lite.TrustOptions{
+				Period: 24 * time.Hour,
+				Height: trustedHeader.Height,
+				Hash:   trustedHeader.Hash(),
+			},
+			benchmarkFullNode,
+			[]provider.Provider{benchmarkFullNode},
+			dbs.New(dbm.NewMemDB(), chainID),
+			lite.Logger(log.TestingLogger()),
+		)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
 		_, err = c.VerifyHeaderAtHeight(1, bTime)
 		if err != nil {
 			b.Fatal(err)

--- a/types/validator_set.go
+++ b/types/validator_set.go
@@ -671,7 +671,7 @@ func (vals *ValidatorSet) VerifyCommit(chainID string, blockID BlockID,
 
 		blsKey, ok := val.PubKey.(bls12_381.PubKeyBls)
 		if !ok {
-			panic(fmt.Sprintf("incorrect key type for combined signatures"))
+			return fmt.Errorf("incorrect key type for combined signatures %T", val.PubKey)
 		}
 		pubKeys.Add(blsKey.RawString())
 		talliedVotingPower += val.VotingPower


### PR DESCRIPTION
Client was not reset in between runs and therefore in later runs was already synced with block 1000. Also, minor modifications to block verification.