### PR TITLE
fix: flaky test reporting invalid header time

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,10 +7,6 @@ on:
       - release/*
       - collaborative-learning
   pull_request:
-    branches:
-      - master
-      - release/*
-      - collaborative-learning
 
 jobs:
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -449,6 +449,24 @@ func ResetTestRootWithChainID(testName string, chainID string) *Config {
 var testGenesisFmt = `{
   "genesis_time": "2018-10-10T08:20:13.695936996Z",
   "chain_id": "%s",
+  "consensus_params": {
+	"block": {
+		"max_bytes": "22020096",
+		"max_gas": "-1",
+		"time_iota_ms": "10"
+	},
+	"evidence": {
+		"max_age_num_blocks": "100000",
+		"max_age_duration": "172800000000000",
+		"max_num": 50
+	},
+	"validator": {
+		"pub_key_types": [
+			"ed25519"
+		]
+	},
+	"version": {}
+  },
   "validators": [
     {
       "pub_key": {

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -939,6 +939,7 @@ func TestConsensusParamsChangesSaveLoad(t *testing.T) {
 	for i := 1; i < N+1; i++ {
 		params[i] = *types.DefaultConsensusParams()
 		params[i].Block.MaxBytes += int64(i)
+		params[i].Block.TimeIotaMs = 10
 	}
 
 	// Build the params history by running updateState


### PR DESCRIPTION
`ExampleClient_Update` test in  `lite2` package  was failing:

```
 $ go test -v -run ^ExampleClient_Update$ ./lite2
=== RUN   ExampleClient_Update
2021/04/29 18:44:23 verify non adjacent from #2 to #2880 failed: invalid header: new header has a time from the future 2021-04-29 16:44:45.127286489 +0000 UTC (now: 2021-04-29 18:44:23.340401835 +0200 CEST m=+13.076297367; max clock drift: 10s)
FAIL    ./lite2  **13.084s**
```


There was a related issue on more recent version: https://github.com/tendermint/tendermint/issues/4489
Backported the fix from v0.34.10 fix at https://github.com/tendermint/tendermint/commit/4b99502d5b75d4d1a199f9b741f3be679ecc8cab
